### PR TITLE
Fix SD-WAN export

### DIFF
--- a/nac_collector/cisco_client_sdwan.py
+++ b/nac_collector/cisco_client_sdwan.py
@@ -378,7 +378,7 @@ class CiscoClientSDWAN(CiscoClient):
             }
             children_entries = []
             associated_parcels = response.json().get("associatedProfileParcels", [])
-            for children_endpoint in endpoint["children"]:
+            for children_endpoint in endpoint.get("children", []):
                 children_endpoint_type = children_endpoint["endpoint"]
                 children_endpoint_type = self.strip_backslash(children_endpoint_type)
                 for parcel in associated_parcels:


### PR DESCRIPTION
Till now, all feature profiles had children endpoints. We've recently introduced a support for new profile that has no children endpoints and this breaks the nac-collector. Fix is to export children only if "children" key exists.