### PR TITLE
sdwan tag bug fix

### DIFF
--- a/nac_collector/cisco_client_sdwan.py
+++ b/nac_collector/cisco_client_sdwan.py
@@ -125,6 +125,7 @@ class CiscoClientSDWAN(CiscoClient):
                 response = self.get_request(self.base_url + endpoint["endpoint"])
 
                 if response:
+                    # Get the JSON content of the response
                     data = response.json()
 
                     if isinstance(data, list):

--- a/nac_collector/cisco_client_sdwan.py
+++ b/nac_collector/cisco_client_sdwan.py
@@ -124,43 +124,43 @@ class CiscoClientSDWAN(CiscoClient):
             ):
                 response = self.get_request(self.base_url + endpoint["endpoint"])
 
-                # Get the JSON content of the response
-                data = response.json()
+                if response:
+                    data = response.json()
 
-                if isinstance(data, list):
-                    for i in data:
-                        endpoint_dict[endpoint["name"]].append(
-                            {
-                                "data": i,
-                                "endpoint": endpoint["endpoint"]
-                                + "/"
-                                + self.get_id_value(i),
-                            }
-                        )
-                elif data.get("data"):
-                    if isinstance(data["data"], list):
-                        for i in data["data"]:
-                            try:
-                                endpoint_dict[endpoint["name"]].append(
-                                    {
-                                        "data": i,
-                                        "endpoint": endpoint["endpoint"]
-                                        + "/"
-                                        + self.get_id_value(i),
-                                    }
-                                )
-                            except TypeError:
-                                endpoint_dict[endpoint["name"]].append(
-                                    {"data": i, "endpoint": endpoint["endpoint"]}
-                                )
-                    else:
-                        endpoint_dict[endpoint["name"]].append(
-                            {"data": data["data"], "endpoint": endpoint["endpoint"]}
-                        )
+                    if isinstance(data, list):
+                        for i in data:
+                            endpoint_dict[endpoint["name"]].append(
+                                {
+                                    "data": i,
+                                    "endpoint": endpoint["endpoint"]
+                                    + "/"
+                                    + self.get_id_value(i),
+                                }
+                            )
+                    elif data.get("data"):
+                        if isinstance(data["data"], list):
+                            for i in data["data"]:
+                                try:
+                                    endpoint_dict[endpoint["name"]].append(
+                                        {
+                                            "data": i,
+                                            "endpoint": endpoint["endpoint"]
+                                            + "/"
+                                            + self.get_id_value(i),
+                                        }
+                                    )
+                                except TypeError:
+                                    endpoint_dict[endpoint["name"]].append(
+                                        {"data": i, "endpoint": endpoint["endpoint"]}
+                                    )
+                        else:
+                            endpoint_dict[endpoint["name"]].append(
+                                {"data": data["data"], "endpoint": endpoint["endpoint"]}
+                            )
 
-                # Save results to dictionary
-                final_dict.update(endpoint_dict)
-                self.log_response(endpoint["endpoint"], response)
+                    # Save results to dictionary
+                    final_dict.update(endpoint_dict)
+                    self.log_response(endpoint["endpoint"], response)
 
             # config groups
             elif "/v1/config-group/" in endpoint["endpoint"]:


### PR DESCRIPTION
The 20.12 SD-WAN Manager version added /v1/tags endpoint that was not supported in 20.9. When you run right now the nac-collector against 20.9 SD-WAN Manager, the error code is 404, response is an empty list and the nac-collector fails with:
AttributeError: 'list' object has no attribute 'json'

The fix is to parse the response to JSON only if it's non-empty.