### PR TITLE
SDWAN | switch to get method for data and header

### DIFF
--- a/nac_collector/controller/sdwan.py
+++ b/nac_collector/controller/sdwan.py
@@ -283,12 +283,12 @@ class CiscoClientSDWAN(CiscoClientController):
                     continue
 
                 data = response.json()
-                if isinstance(data["data"], list):
+                if isinstance(data.get("data"), list):
                     for i in data["data"]:
                         try:
                             endpoint_dict[endpoint["name"]].append(
                                 {
-                                    "header": data["header"],
+                                    "header": data.get("header", {}),
                                     "data": i,
                                     "endpoint": device_template_endpoint,
                                 }
@@ -296,7 +296,7 @@ class CiscoClientSDWAN(CiscoClientController):
                         except TypeError:
                             endpoint_dict[endpoint["name"]].append(
                                 {
-                                    "header": data["header"],
+                                    "header": data.get("header", {}),
                                     "data": i,
                                     "endpoint": device_template_endpoint,
                                 }
@@ -304,8 +304,8 @@ class CiscoClientSDWAN(CiscoClientController):
                 else:
                     endpoint_dict[endpoint["name"]].append(
                         {
-                            "header": data["header"],
-                            "data": data["data"],
+                            "header": data.get("header", {}),
+                            "data": data.get("data", {}),
                             "endpoint": device_template_endpoint,
                         }
                     )


### PR DESCRIPTION
For certain API calls where the result is empty, the sdwan.py was trying to access the variables without any conditions and failing when they didnt exist.

added get method with fallback to avoid running in to exception.