### PR TITLE
meraki: Fix organization filtering

### DIFF
--- a/nac_collector/controller/meraki.py
+++ b/nac_collector/controller/meraki.py
@@ -51,7 +51,10 @@ class CiscoClientMERAKI(CiscoClientController):
             ssl_verify,
         )
 
-        self.allowed_org_ids = os.getenv("NAC_MERAKI_ORG_IDS", "").split(",")
+        self.allowed_org_ids: list[str] | None = None
+        allowed_org_ids_env = os.getenv("NAC_MERAKI_ORG_IDS", "")
+        if allowed_org_ids_env != "":
+            self.allowed_org_ids = allowed_org_ids_env.split(",")
 
     def authenticate(self) -> bool:
         """
@@ -210,7 +213,7 @@ class CiscoClientMERAKI(CiscoClientController):
         if not isinstance(data, list):
             return data
 
-        if len(self.allowed_org_ids) == 0:
+        if self.allowed_org_ids is None:
             return data
 
         return [


### PR DESCRIPTION
A mistake when addressing
https://github.com/netascode/nac-collector/pull/159#discussion_r2489602836 made the meraki collector return no data (skip all organizations) if `NAC_MERAKI_ORG_IDS` was empty or unset.

This is due to the different behavior of `str.split`: `str.split("")` returns `[]` while `str.split("", ",")` returns `[""]`
(https://docs.python.org/3.3/library/stdtypes.html#str.split).

Check whether the variable is unset/blank explicitly.