### PR TITLE
add new site_settings endpoint

### DIFF
--- a/nac_collector/resources/endpoints/catalystcenter.yaml
+++ b/nac_collector/resources/endpoints/catalystcenter.yaml
@@ -125,3 +125,5 @@
   endpoint: /api/v1/template-programmer/extendedTemplates
 - name: vlanToSsids
   endpoint: /dna/intent/api/v1/sda/fabrics/%v/vlanToSsids
+- name: site_settings
+  endpoint: /api/v1/commonsetting/global

--- a/nac_collector/resources/lookups/catalystcenter.yaml
+++ b/nac_collector/resources/lookups/catalystcenter.yaml
@@ -53,3 +53,8 @@
   source_key: id
   target_endpoint: /dna/intent/api/v1/sda/fabrics/%v/vlanToSsids
   target_key: siteId
+- endpoint: /api/v1/commonsetting/global
+  source_endpoint: /dna/intent/api/v2/site
+  source_key: id
+  target_endpoint: /api/v1/commonsetting/global/%v
+  target_key: siteId


### PR DESCRIPTION
and new site_settings api endpoint to fetch
This one should contain all the same data as site children endpoints, but it has no rate limit - so whole process should be much faster in catc with many sites