### PR TITLE
meraki: Use asyncio to run more requests per second

### DIFF
--- a/nac_collector/controller/meraki.py
+++ b/nac_collector/controller/meraki.py
@@ -318,31 +318,6 @@ class CiscoClientMERAKI(CiscoClientController):
 
         await asyncio.gather(
             *(
-                self.get_child_endpoint_for_parent_instances(
-                    parent_endpoint,
-                    parent_endpoint_uri,
-                    grandparent_endpoints_ids,
-                    parent_instances,
-                    children_endpoint,
-                    progress,
-                    progress_task,
-                )
-                for children_endpoint in child_endpoints
-            )
-        )
-
-    async def get_child_endpoint_for_parent_instances(
-        self,
-        parent_endpoint: dict[str, Any],
-        parent_endpoint_uri: str,
-        grandparent_endpoints_ids: list[str | int],
-        parent_instances: list[dict[str, Any]],
-        children_endpoint: dict[str, Any],
-        progress: Progress,
-        progress_task: TaskID,
-    ) -> None:
-        await asyncio.gather(
-            *(
                 self.get_child_endpoint_for_parent_instance(
                     parent_endpoint_uri,
                     grandparent_endpoints_ids,
@@ -351,6 +326,7 @@ class CiscoClientMERAKI(CiscoClientController):
                     progress,
                     progress_task,
                 )
+                for children_endpoint in child_endpoints
                 for parent_instance in parent_instances
             )
         )


### PR DESCRIPTION
[meraki: Use meraki.aio.AsyncRestSession](https://github.com/netascode/nac-collector/pull/186/changes/a0fa87c7ef58fe7a31c5c16c7b356af41d05719b)
Currently, a request is only being made
after the previous request finishes.
This results in only 3-5 requests per second being sent,
while the rate limit is 10 requests per second per organization:
https://developer.cisco.com/meraki/api-v1/rate-limit/#rate-limits-per-organization

Use the async Dashboard API
to make requests without waiting for responses.
This is a naive implementation without a redesign of the flow,
using `asyncio.gather` in all loops.

There are issues with this implementation:
- The rate limit is handled naively in Meraki nac-collector
  with a synchronized sleep(0.1)
  to ensure only 10 requests are started per second.
  Without this, collection fails for many endpoints
  with "Reached retry limit: None" and a 429 status code, as
  `meraki.aio.AsyncRestSession` does not seem to limit its requests
  to match the rate limit - it seems to only limit the number of
  concurrent requests (8 by default).
  It also does an asynchronous sleep for exactly the "Retry-After" time
  returned in a 429 response.
  This results in getting many 429 responses,
  then getting them again for about as many requests later.
- The API returns HTML instead of JSON for many of the 404 responses (for nonexistent endpoints).
  They were previously returned as the first few bytes of the HTML.
  `meraki.aio.AsyncRestSession` instead raises a `JSONDecodeError`
  as it tries to parse them unconditionally.
  The old behavior was useless, but the new behavior is even worse
  as it loses the status code information.
  The endpoints are overridden to the correct URIs manually in #185, but new ones are bound to appear in newer API spec versions.
  https://github.com/meraki/dashboard-api-python/pull/319 is open to fix the exception handling in the library.

[meraki: Make progress display clear](https://github.com/netascode/nac-collector/pull/186/changes/ea00f936141a2d428f70c448ccd04037d3a2cfbd)
The progress bars currently mirror the structure of the code:
For each endpoint with children, it look like:

    Fetching children of /parent
    Fetching /parent/child for each parent

and so on for each level of the tree.
The progress bars stay at one point for a long time
whenever an endpoint has its own children.
This makes it hard to tell how much work is actually remaining.

This is also made worse by using `asyncio.gather()`
to process multiple children at the same time,
which creates enough empty progress bars to fill the whole screen
for most of the run.

Replace this with a single progress bar,
still keeping the current structure of the code,
but relying on asyncio queuing many requests ahead of time:
use the number of queued requests as the total
and advance the progress bar by 1 on each completed request.

Sort child endpoints so that endpoints with children
are queued first,
to hopefully count the correct total number of requests sooner.

In my testing, this counts about half of the total requests
in the beginning and adds most of the other half 20 seconds in,
with the whole run taking 2m12s.

Also, add progress columns for the number of completed/total requests
and time elapsed / remaining (estimated).