### PR TITLE
Fix wireless controller AP location collection 

### DIFF
--- a/nac_collector/controller/catalystcenter.py
+++ b/nac_collector/controller/catalystcenter.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import datetime
 import logging
 import os
+import re
 import threading
 from typing import Any
 
@@ -272,6 +273,7 @@ class CiscoClientCATALYSTCENTER(CiscoClientController):
             id_list = []
         data_list = []
         for id_ in id_list:
+            id_ = self._sanitize_id(str(id_))
             lookup_endpoint = self.id_lookup[endpoint_key]["target_endpoint"].replace(
                 "%v", id_
             )
@@ -343,8 +345,15 @@ class CiscoClientCATALYSTCENTER(CiscoClientController):
         for p in params:
             x = i.get(p)
             if x is not None:
-                return str(x)
+                return CiscoClientCATALYSTCENTER._sanitize_id(str(x))
         return None
+
+    @staticmethod
+    def _sanitize_id(value: str) -> str:
+        """
+        Strip whitespace and non-printable characters from an ID value.
+        """
+        return re.sub(r"[\x00-\x1f\x7f-\x9f\s]", "", value)
 
     def process_endpoint(self, endpoint: dict[str, Any]) -> dict[str, Any] | None:
         with self.lock:
@@ -423,11 +432,12 @@ class CiscoClientCATALYSTCENTER(CiscoClientController):
                     parent_ids = [self.global_site_id]
 
                 for parent_id in parent_ids:
+                    sanitized_parent_id = self._sanitize_id(str(parent_id))
                     child_dict = CiscoClientController.create_endpoint_dict(
                         children_endpoint
                     )
 
-                    joined_endpoint = f"{endpoint['endpoint']}/{parent_id}{children_endpoint['endpoint']}"
+                    joined_endpoint = f"{endpoint['endpoint']}/{sanitized_parent_id}{children_endpoint['endpoint']}"
                     data = self.fetch_data_pagination(joined_endpoint)
                     child_dict = self.process_endpoint_data(
                         children_endpoint, child_dict, data, parent_id

--- a/nac_collector/resources/endpoint_overrides/catalystcenter.yaml
+++ b/nac_collector/resources/endpoint_overrides/catalystcenter.yaml
@@ -56,11 +56,12 @@ extra_endpoints:
 
 - name: network_devices
   endpoint: /dna/intent/api/v1/network-device
-  children:
-  - name: wireless_controller_primary_managed_ap_locations
-    endpoint: /dna/intent/api/v1/wirelessControllers/%v/primaryManagedApLocations
-  - name: wireless_controller_secondary_managed_ap_locations
-    endpoint: /dna/intent/api/v1/wirelessControllers/%v/secondaryManagedApLocations
+
+- name: wireless_controller_primary_managed_ap_locations
+  endpoint: /dna/intent/api/v1/wirelessControllers/%v/primaryManagedApLocations
+
+- name: wireless_controller_secondary_managed_ap_locations
+  endpoint: /dna/intent/api/v1/wirelessControllers/%v/secondaryManagedApLocations
 
 - name: device_detail
   endpoint: /dna/intent/api/v1/device-detail

--- a/nac_collector/resources/endpoints/catalystcenter.yaml
+++ b/nac_collector/resources/endpoints/catalystcenter.yaml
@@ -79,13 +79,6 @@
   endpoint: /api/v1/commonsetting/global
 - name: network_devices
   endpoint: /dna/intent/api/v1/network-device
-  children:
-  - name: wireless_controller_primary_managed_ap_locations
-    endpoint: 
-      /dna/intent/api/v1/wirelessControllers/%v/primaryManagedApLocations
-  - name: wireless_controller_secondary_managed_ap_locations
-    endpoint: 
-      /dna/intent/api/v1/wirelessControllers/%v/secondaryManagedApLocations
 - name: network_profile
   endpoint: /api/v1/siteprofile?populated=true
   id_field: siteProfileUuid
@@ -149,6 +142,10 @@
   endpoint: /dna/intent/api/v1/business/sda/virtualnetwork/ippool
 - name: vlanToSsids
   endpoint: /dna/intent/api/v1/sda/fabrics/%v/vlanToSsids
+- name: wireless_controller_primary_managed_ap_locations
+  endpoint: /dna/intent/api/v1/wirelessControllers/%v/primaryManagedApLocations
+- name: wireless_controller_secondary_managed_ap_locations
+  endpoint: /dna/intent/api/v1/wirelessControllers/%v/secondaryManagedApLocations
 - name: wireless_enterprise_ssid
   endpoint: /dna/intent/api/v1/enterprise-ssid
 - name: wireless_interface

--- a/nac_collector/resources/lookups/catalystcenter.yaml
+++ b/nac_collector/resources/lookups/catalystcenter.yaml
@@ -63,4 +63,14 @@
   source_key: id
   target_endpoint: /dna/intent/api/v1/sda/fabricDevices/layer3Handoffs/sdaTransits?fabricId=%v
   target_key: fabricId
+- endpoint: /dna/intent/api/v1/wirelessControllers/%v/primaryManagedApLocations
+  source_endpoint: /dna/intent/api/v1/network-device
+  source_key: id
+  target_endpoint: /dna/intent/api/v1/wirelessControllers/%v/primaryManagedApLocations
+  target_key: deviceId
+- endpoint: /dna/intent/api/v1/wirelessControllers/%v/secondaryManagedApLocations
+  source_endpoint: /dna/intent/api/v1/network-device
+  source_key: id
+  target_endpoint: /dna/intent/api/v1/wirelessControllers/%v/secondaryManagedApLocations
+  target_key: deviceId
 


### PR DESCRIPTION
Move primary/secondary managed AP location endpoints from broken network_devices children to standalone top-level endpoints with lookups. The children-based approach produced invalid URLs.

Also add ID sanitization in catalystcenter.py to strip non-printable characters (tabs, newlines) from device IDs, as CATC allows these in site names.