### PR TITLE
Add --request-delay and --max-concurrency CLI options (#214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Options:
                         Request timeout in seconds [default: 30]
   -o, --output TEXT     Path to the output ZIP file [default: nac-collector.zip]
   --devices-file TEXT   Path to the device inventory YAML file (for device-based solutions)
+  --request-delay FLOAT Seconds to pause after each successful API request [default: 0.0]
+  --max-concurrency INTEGER
+                        Maximum number of concurrent workers. Default: unlimited for
+                        controller-based solutions, 10 for device-based solutions.
   --version             Show version and exit
   --help                Show this message and exit
 ```
@@ -89,6 +93,19 @@ nac-collector -s ISE -v DEBUG --fetch-latest
 
 # Without environment variables
 nac-collector -s ISE --username USERNAME --password PASSWORD --url URL -v DEBUG --fetch-latest
+```
+
+### Throttling / rate limiting
+
+To reduce API pressure on busy controllers, use `--request-delay` to pause between
+successful requests and `--max-concurrency` to cap concurrent workers:
+
+```sh
+# Add a 0.5s pause between successful requests
+nac-collector -s ISE --request-delay 0.5 --fetch-latest
+
+# Cap Catalyst Center to 3 concurrent workers and 0.2s between requests
+nac-collector -s CATALYSTCENTER --max-concurrency 3 --request-delay 0.2
 ```
 
 ### Catalyst Center

--- a/nac_collector/cli/main.py
+++ b/nac_collector/cli/main.py
@@ -8,7 +8,13 @@ from rich.logging import RichHandler
 
 import nac_collector
 from nac_collector.cli import console
-from nac_collector.constants import MAX_RETRIES, RETRY_AFTER, TIMEOUT
+from nac_collector.constants import (
+    DEFAULT_DEVICE_CONCURRENCY,
+    MAX_RETRIES,
+    REQUEST_DELAY,
+    RETRY_AFTER,
+    TIMEOUT,
+)
 from nac_collector.controller.base import CiscoClientController
 from nac_collector.controller.catalystcenter import CiscoClientCATALYSTCENTER
 from nac_collector.controller.fmc import CiscoClientFMC
@@ -173,6 +179,20 @@ def main(
             help="Path to devices inventory YAML file (for device-based solutions)",
         ),
     ] = None,
+    request_delay: Annotated[
+        float,
+        typer.Option(
+            "--request-delay",
+            help="Delay in seconds between API requests (e.g. 0.5 for 500ms)",
+        ),
+    ] = REQUEST_DELAY,
+    max_concurrency: Annotated[
+        int | None,
+        typer.Option(
+            "--max-concurrency",
+            help="Max concurrent requests (threads for Catalyst Center/devices, default: unlimited for controllers, 10 for devices)",
+        ),
+    ] = None,
     version: Annotated[
         bool | None,
         typer.Option(
@@ -224,6 +244,8 @@ def main(
             )
 
         # Create appropriate client based on solution
+        device_concurrency = max_concurrency or DEFAULT_DEVICE_CONCURRENCY
+
         if solution == Solution.IOSXE:
             iosxe_client = CiscoClientIOSXE(
                 devices=devices,
@@ -233,6 +255,7 @@ def main(
                 retry_after=RETRY_AFTER,
                 timeout=timeout,
                 ssl_verify=False,
+                max_concurrency=device_concurrency,
             )
             # Collect from all devices and write to archive
             iosxe_client.collect_and_write_to_archive(output_file)
@@ -245,6 +268,7 @@ def main(
                 retry_after=RETRY_AFTER,
                 timeout=timeout,
                 ssl_verify=False,
+                max_concurrency=device_concurrency,
             )
             # Collect from all devices and write to archive
             iosxr_client.collect_and_write_to_archive(output_file)
@@ -257,6 +281,7 @@ def main(
                 retry_after=RETRY_AFTER,
                 timeout=timeout,
                 ssl_verify=False,
+                max_concurrency=device_concurrency,
             )
             # Collect from all devices and write to archive
             nxos_client.collect_and_write_to_archive(output_file)
@@ -325,6 +350,7 @@ def main(
                     retry_after=RETRY_AFTER,
                     timeout=timeout,
                     ssl_verify=False,
+                    request_delay=request_delay,
                 )
             if solution == Solution.CDFMC:
                 # For CDFMC, use FMC client but set cdfmc=True to adjust behavior
@@ -337,7 +363,20 @@ def main(
                     retry_after=RETRY_AFTER,
                     timeout=timeout,
                     ssl_verify=False,
+                    request_delay=request_delay,
                     cdfmc=True,
+                )
+            elif solution == Solution.CATALYSTCENTER:
+                client = CiscoClientCATALYSTCENTER(
+                    username=username,
+                    password=password,
+                    base_url=url,
+                    max_retries=MAX_RETRIES,
+                    retry_after=RETRY_AFTER,
+                    timeout=timeout,
+                    ssl_verify=False,
+                    request_delay=request_delay,
+                    max_concurrency=max_concurrency,
                 )
             else:
                 # For other solutions, don't pass domain parameter
@@ -349,6 +388,7 @@ def main(
                     retry_after=RETRY_AFTER,
                     timeout=timeout,
                     ssl_verify=False,
+                    request_delay=request_delay,
                 )
 
             # Authenticate

--- a/nac_collector/constants.py
+++ b/nac_collector/constants.py
@@ -12,6 +12,8 @@ GIT_TMP = Path("./tmp")
 MAX_RETRIES = 5
 RETRY_AFTER = 60
 TIMEOUT = 30
+REQUEST_DELAY = 0.0
+DEFAULT_DEVICE_CONCURRENCY = 10
 
 # ISE-specific constants
 # ISE ERS API pagination size parameter

--- a/nac_collector/controller/base.py
+++ b/nac_collector/controller/base.py
@@ -22,6 +22,7 @@ class CiscoClientController(ABC):
         max_retries (int): The maximum number of times to retry the request if the status code is 429.
         retry_after (int): The number of seconds to wait before retrying the request if the status code is 429.
         timeout (int): The number of seconds to wait for the server to send data before giving up.
+        request_delay (float, optional): Delay in seconds between API requests. Defaults to 0.0.
     """
 
     def __init__(
@@ -33,6 +34,7 @@ class CiscoClientController(ABC):
         retry_after: int,
         timeout: int,
         ssl_verify: bool = False,
+        request_delay: float = 0.0,
     ) -> None:
         self.username = username
         self.password = password
@@ -41,6 +43,7 @@ class CiscoClientController(ABC):
         self.retry_after = retry_after
         self.timeout = timeout
         self.ssl_verify = ssl_verify
+        self.request_delay = request_delay
         self.client: httpx.Client | None = None
         # Create an instance of the YAML class
         self.yaml = YAML(typ="safe", pure=True)
@@ -120,6 +123,8 @@ class CiscoClientController(ABC):
 
             elif response.status_code == 200:
                 # If the status code is 200 (OK), return the response
+                if self.request_delay > 0:
+                    time.sleep(self.request_delay)
                 return response
             else:
                 # If the status code is neither 429 nor 200, log an error and continue to the next iteration
@@ -170,6 +175,8 @@ class CiscoClientController(ABC):
                 time.sleep(self.retry_after)
             elif 200 <= response.status_code < 300:
                 # If the status code is 2XX (success), return the response
+                if self.request_delay > 0:
+                    time.sleep(self.request_delay)
                 return response
             else:
                 # If the status code is neither 429 nor 200, log an error and continue to the next iteration

--- a/nac_collector/controller/catalystcenter.py
+++ b/nac_collector/controller/catalystcenter.py
@@ -81,13 +81,17 @@ class CiscoClientCATALYSTCENTER(CiscoClientController):
         retry_after: int,
         timeout: int,
         ssl_verify: bool,
+        request_delay: float = 0.0,
+        max_concurrency: int | None = None,
     ) -> None:
         self.db = TinyDB("./tmp_db.json")
         self.job = Query()
         self.start_time = datetime.datetime.now().isoformat()
         self.lock = threading.Lock()
+        self.max_concurrency = max_concurrency
         super().__init__(
-            username, password, base_url, max_retries, retry_after, timeout, ssl_verify
+            username, password, base_url, max_retries, retry_after, timeout, ssl_verify,
+            request_delay=request_delay,
         )
         with self.lock:
             existing = self.db.get(self.job.url == self.base_url)
@@ -316,7 +320,7 @@ class CiscoClientCATALYSTCENTER(CiscoClientController):
             console=None,
         ) as progress:
             task = progress.add_task("Processing endpoints", total=len(endpoints))
-            with concurrent.futures.ThreadPoolExecutor() as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_concurrency) as executor:
                 results = []
                 futures = [
                     executor.submit(self.process_endpoint, endpoint)
@@ -467,7 +471,7 @@ class CiscoClientCATALYSTCENTER(CiscoClientController):
                                         children_endpoint["name"]
                                     ] = child_dict[children_endpoint["name"]]
 
-            with concurrent.futures.ThreadPoolExecutor() as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_concurrency) as executor:
                 list(executor.map(_process_child, endpoint["children"]))
         with self.lock:
             self.db.upsert(

--- a/nac_collector/controller/fmc.py
+++ b/nac_collector/controller/fmc.py
@@ -39,10 +39,12 @@ class CiscoClientFMC(CiscoClientController):
         retry_after: int,
         timeout: int,
         ssl_verify: bool,
+        request_delay: float = 0.0,
         cdfmc: bool = False,
     ) -> None:
         super().__init__(
-            username, password, base_url, max_retries, retry_after, timeout, ssl_verify
+            username, password, base_url, max_retries, retry_after, timeout, ssl_verify,
+            request_delay=request_delay,
         )
         self.x_auth_refresh_token: str | None = None
         self.cdfmc = cdfmc

--- a/nac_collector/controller/ise.py
+++ b/nac_collector/controller/ise.py
@@ -39,9 +39,11 @@ class CiscoClientISE(CiscoClientController):
         retry_after: int,
         timeout: int,
         ssl_verify: bool,
+        request_delay: float = 0.0,
     ) -> None:
         super().__init__(
-            username, password, base_url, max_retries, retry_after, timeout, ssl_verify
+            username, password, base_url, max_retries, retry_after, timeout, ssl_verify,
+            request_delay=request_delay,
         )
 
     def reconstruct_url_with_base(self, href: str) -> str:

--- a/nac_collector/controller/meraki.py
+++ b/nac_collector/controller/meraki.py
@@ -46,6 +46,7 @@ class CiscoClientMERAKI(CiscoClientController):
         retry_after: int,
         timeout: int,
         ssl_verify: bool,
+        request_delay: float = 0.0,
     ) -> None:
         super().__init__(
             username,
@@ -55,6 +56,7 @@ class CiscoClientMERAKI(CiscoClientController):
             retry_after,
             timeout,
             ssl_verify,
+            request_delay=request_delay,
         )
 
         self.allowed_org_ids: list[str] | None = None

--- a/nac_collector/controller/ndo.py
+++ b/nac_collector/controller/ndo.py
@@ -29,10 +29,12 @@ class CiscoClientNDO(CiscoClientController):
         retry_after: int,
         timeout: int,
         ssl_verify: bool,
+        request_delay: float = 0.0,
     ) -> None:
         self.domain = domain
         super().__init__(
-            username, password, base_url, max_retries, retry_after, timeout, ssl_verify
+            username, password, base_url, max_retries, retry_after, timeout, ssl_verify,
+            request_delay=request_delay,
         )
 
     def authenticate(self) -> bool:

--- a/nac_collector/controller/sdwan.py
+++ b/nac_collector/controller/sdwan.py
@@ -35,9 +35,11 @@ class CiscoClientSDWAN(CiscoClientController):
         retry_after: int,
         timeout: int,
         ssl_verify: bool,
+        request_delay: float = 0.0,
     ) -> None:
         super().__init__(
-            username, password, base_url, max_retries, retry_after, timeout, ssl_verify
+            username, password, base_url, max_retries, retry_after, timeout, ssl_verify,
+            request_delay=request_delay,
         )
 
     def authenticate(self) -> bool:

--- a/nac_collector/device/base.py
+++ b/nac_collector/device/base.py
@@ -32,6 +32,7 @@ class CiscoClientDevice(ABC):
         retry_after: int,
         timeout: int,
         ssl_verify: bool = False,
+        max_concurrency: int = 10,
     ) -> None:
         self.devices = devices
         self.default_username = default_username
@@ -40,6 +41,7 @@ class CiscoClientDevice(ABC):
         self.retry_after = retry_after
         self.timeout = timeout
         self.ssl_verify = ssl_verify
+        self.max_concurrency = max_concurrency
         self.logger = logging.getLogger(__name__)
 
     @abstractmethod
@@ -238,7 +240,7 @@ class CiscoClientDevice(ABC):
             ) as progress:
                 task = progress.add_task("Processing devices", total=len(self.devices))
 
-                with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_concurrency) as executor:
                     futures = {
                         executor.submit(
                             self._collect_with_error_handling, device

--- a/tests/unit/test_cisco_client_controller.py
+++ b/tests/unit/test_cisco_client_controller.py
@@ -263,6 +263,69 @@ class TestPostRequest:
         assert result == mock_response
 
 
+class TestRequestDelay:
+    def _make_client(self, request_delay):
+        return ConcreteCiscoClient(
+            username="user",
+            password="pass",
+            base_url="https://example.com",
+            max_retries=3,
+            retry_after=1,
+            timeout=5,
+            ssl_verify=False,
+            request_delay=request_delay,
+        )
+
+    def test_get_request_applies_delay_on_success(self, mock_httpx_client):
+        client = self._make_client(request_delay=0.25)
+        client.client = mock_httpx_client
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_httpx_client.get.return_value = mock_response
+
+        with patch("nac_collector.controller.base.time.sleep") as mock_sleep:
+            result = client.get_request("https://example.com/api/test")
+
+        assert result == mock_response
+        mock_sleep.assert_called_once_with(0.25)
+
+    def test_get_request_zero_delay_does_not_sleep(self, mock_httpx_client):
+        client = self._make_client(request_delay=0.0)
+        client.client = mock_httpx_client
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_httpx_client.get.return_value = mock_response
+
+        with patch("nac_collector.controller.base.time.sleep") as mock_sleep:
+            client.get_request("https://example.com/api/test")
+
+        mock_sleep.assert_not_called()
+
+    def test_post_request_applies_delay_on_success(self, mock_httpx_client):
+        client = self._make_client(request_delay=0.1)
+        client.client = mock_httpx_client
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_httpx_client.post.return_value = mock_response
+
+        with patch("nac_collector.controller.base.time.sleep") as mock_sleep:
+            result = client.post_request("https://example.com/api/test", {"x": 1})
+
+        assert result == mock_response
+        mock_sleep.assert_called_once_with(0.1)
+
+    def test_default_request_delay_is_zero(self):
+        client = ConcreteCiscoClient(
+            username="u",
+            password="p",
+            base_url="https://example.com",
+            max_retries=1,
+            retry_after=1,
+            timeout=1,
+        )
+        assert client.request_delay == 0.0
+
+
 class TestLogResponse:
     def test_log_response_success(self, cisco_client, caplog):
         with caplog.at_level("INFO"):

--- a/tests/unit/test_cisco_client_device.py
+++ b/tests/unit/test_cisco_client_device.py
@@ -323,6 +323,57 @@ class TestCollectAndWriteToArchive:
             )  # Original name preserved in content
 
 
+class TestMaxConcurrency:
+    def test_default_max_concurrency_is_ten(self, sample_devices):
+        client = ConcreteCiscoClientDevice(
+            devices=sample_devices,
+            default_username="user",
+            default_password="pass",
+            max_retries=1,
+            retry_after=1,
+            timeout=5,
+        )
+        assert client.max_concurrency == 10
+
+    def test_explicit_max_concurrency_override(self, sample_devices):
+        client = ConcreteCiscoClientDevice(
+            devices=sample_devices,
+            default_username="user",
+            default_password="pass",
+            max_retries=1,
+            retry_after=1,
+            timeout=5,
+            max_concurrency=3,
+        )
+        assert client.max_concurrency == 3
+
+    @patch("zipfile.ZipFile")
+    @patch("concurrent.futures.ThreadPoolExecutor")
+    def test_collect_uses_configured_max_concurrency(
+        self, mock_executor, mock_zipfile, sample_devices
+    ):
+        client = ConcreteCiscoClientDevice(
+            devices=sample_devices,
+            default_username="user",
+            default_password="pass",
+            max_retries=1,
+            retry_after=1,
+            timeout=5,
+            max_concurrency=4,
+        )
+
+        mock_future = MagicMock()
+        mock_future.result.return_value = {"device": "x", "config": "y"}
+        mock_executor_instance = mock_executor.return_value.__enter__.return_value
+        mock_executor_instance.submit.return_value = mock_future
+
+        with patch("concurrent.futures.as_completed", return_value=[mock_future]):
+            client.devices = [{"name": "OnlyDevice"}]
+            client.collect_and_write_to_archive("out.zip")
+
+        mock_executor.assert_called_once_with(max_workers=4)
+
+
 class TestAbstractMethods:
     def test_abstract_methods_must_be_implemented(self):
         # Verify that CiscoClientDevice is abstract and cannot be instantiated

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -80,6 +80,7 @@ class TestDeviceBasedSolutions:
             retry_after=60,
             timeout=30,
             ssl_verify=False,
+            max_concurrency=10,
         )
 
         # Verify collection was called with default output file
@@ -257,6 +258,7 @@ class TestDeviceBasedSolutions:
             retry_after=60,
             timeout=30,
             ssl_verify=False,
+            max_concurrency=10,
         )
 
         # Verify collection was called with default output file
@@ -335,6 +337,7 @@ class TestControllerBasedSolutions:
             retry_after=60,
             timeout=30,
             ssl_verify=False,
+            request_delay=0.0,
         )
 
         # Verify authentication and collection
@@ -397,6 +400,132 @@ class TestControllerBasedSolutions:
         assert exc_info.value.exit_code == 1
         mock_client.authenticate.assert_called_once()
         mock_client.get_from_endpoints_data.assert_not_called()
+
+
+class TestThrottlingOptions:
+    @patch("nac_collector.cli.main.CiscoClientIOSXE")
+    @patch("nac_collector.cli.main.load_devices_from_file")
+    def test_device_solution_forwards_max_concurrency(
+        self, mock_load_devices, mock_iosxe_class, sample_devices_yaml
+    ):
+        mock_load_devices.return_value = [
+            {"name": "Device1", "url": "https://device1.example.com"}
+        ]
+        mock_iosxe_class.return_value = MagicMock()
+
+        with patch("nac_collector.cli.main.time.time", side_effect=[0, 5]):
+            with pytest.raises(typer.Exit):
+                main(
+                    solution=Solution.IOSXE,
+                    username="test_user",
+                    password="test_pass",
+                    url="http://unused.com",
+                    devices_file=sample_devices_yaml,
+                    verbosity=LogLevel.WARNING,
+                    fetch_latest=False,
+                    endpoints_file=None,
+                    timeout=30,
+                    output=None,
+                    request_delay=0.5,
+                    max_concurrency=3,
+                    version=None,
+                )
+
+        # Device clients only accept max_concurrency (not request_delay).
+        mock_iosxe_class.assert_called_once_with(
+            devices=mock_load_devices.return_value,
+            default_username="test_user",
+            default_password="test_pass",
+            max_retries=5,
+            retry_after=60,
+            timeout=30,
+            ssl_verify=False,
+            max_concurrency=3,
+        )
+
+    @patch("nac_collector.cli.main.CiscoClientISE")
+    @patch("nac_collector.cli.main.EndpointResolver.resolve_endpoint_data")
+    def test_controller_solution_forwards_request_delay(
+        self, mock_resolver, mock_ise_class
+    ):
+        mock_resolver.return_value = [{"name": "test", "endpoint": "/test"}]
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client.get_from_endpoints_data.return_value = {"test": "data"}
+        mock_ise_class.return_value = mock_client
+
+        with patch("nac_collector.cli.main.time.time", side_effect=[0, 5]):
+            with pytest.raises(typer.Exit):
+                main(
+                    solution=Solution.ISE,
+                    username="ise_user",
+                    password="ise_pass",
+                    url="https://ise-server.com",
+                    devices_file=None,
+                    verbosity=LogLevel.WARNING,
+                    fetch_latest=False,
+                    endpoints_file=None,
+                    timeout=30,
+                    output=None,
+                    request_delay=0.25,
+                    max_concurrency=5,
+                    version=None,
+                )
+
+        # ISE only accepts request_delay (max_concurrency is Catalyst-Center-only).
+        mock_ise_class.assert_called_once_with(
+            username="ise_user",
+            password="ise_pass",
+            base_url="https://ise-server.com",
+            max_retries=5,
+            retry_after=60,
+            timeout=30,
+            ssl_verify=False,
+            request_delay=0.25,
+        )
+
+    @patch("nac_collector.cli.main.CiscoClientCATALYSTCENTER")
+    @patch("nac_collector.cli.main.EndpointResolver.resolve_endpoint_data")
+    def test_catalyst_center_forwards_both_options(
+        self, mock_resolver, mock_catc_class
+    ):
+        mock_resolver.return_value = [{"name": "test", "endpoint": "/test"}]
+
+        mock_client = MagicMock()
+        mock_client.authenticate.return_value = True
+        mock_client.get_from_endpoints_data.return_value = {"test": "data"}
+        mock_catc_class.return_value = mock_client
+
+        with patch("nac_collector.cli.main.time.time", side_effect=[0, 5]):
+            with pytest.raises(typer.Exit):
+                main(
+                    solution=Solution.CATALYSTCENTER,
+                    username="catc_user",
+                    password="catc_pass",
+                    url="https://catc-server.com",
+                    devices_file=None,
+                    verbosity=LogLevel.WARNING,
+                    fetch_latest=False,
+                    endpoints_file=None,
+                    timeout=30,
+                    output=None,
+                    request_delay=0.3,
+                    max_concurrency=4,
+                    version=None,
+                )
+
+        mock_catc_class.assert_called_once_with(
+            username="catc_user",
+            password="catc_pass",
+            base_url="https://catc-server.com",
+            max_retries=5,
+            retry_after=60,
+            timeout=30,
+            ssl_verify=False,
+            request_delay=0.3,
+            max_concurrency=4,
+        )
 
 
 class TestSpecialCases:


### PR DESCRIPTION
Closes #214

## Summary                                                                                                
  Adds two optional CLI flags to reduce API aggressiveness against busy controllers and prevent rate-limit /
   DoS on production environments:                                                                          
                                                         
  - `--request-delay <float>` (default `0.0`): pause in seconds after each successful API request.          
  - `--max-concurrency <int>` (default: unlimited for controllers, `10` for device-based solutions): caps
  the concurrent worker pool.                                                                               
   
  Both flags are optional and defaults preserve current behaviour (no delay, same concurrency as before).   
                                                         
  ## Where each flag takes effect                                                                           
   
  | Solution | `--request-delay` | `--max-concurrency` |                                                    
  |---|---|---|                                          
  | CATALYSTCENTER | ✅ every request | ✅ both `ThreadPoolExecutor` pools |
  | ISE / SDWAN / NDO / FMC / CDFMC | ✅ every request | — (no thread pool) |                               
  | MERAKI | forwarded (Meraki uses its own async throttle) | — |
  | IOSXE / IOSXR / NXOS | — | ✅ replaces hardcoded 10-worker pool |                                       
                                                                                                            
  ## Example usage                                                                                          
  ```sh                                                                                                     
  nac-collector -s ISE --request-delay 0.5 --fetch-latest
  nac-collector -s CATALYSTCENTER --max-concurrency 3 --request-delay 0.2
  ```                                                                                                       
   
  ## Test plan                                                                                              
  - [x] `pytest tests/unit -q` — all unit tests pass (including new coverage for request delay, device
  `max_concurrency`, and CLI forwarding for Catalyst Center / ISE / IOSXE)                                  
  - [x] `ruff check` clean
  - [x] `mypy` clean                                                                                        
  - [x] Manual smoke test against a real Catalyst Center with both flags combined
