### PR TITLE
feat: add dictionary attribute collection endpoint

### DIFF
--- a/nac_collector/controller/ise.py
+++ b/nac_collector/controller/ise.py
@@ -250,11 +250,9 @@ class CiscoClientISE(CiscoClientController):
                     parent_endpoint_ids = []
 
                     for item in endpoint_dict[endpoint["name"]]:
-                        # Add the item's id to the list
-                        try:
-                            parent_endpoint_ids.append(item["data"]["id"])
-                        except KeyError:
-                            continue
+                        id_value = self.get_id_value(item.get("data", {}))
+                        if id_value is not None:
+                            parent_endpoint_ids.append(id_value)
 
                     for children_endpoint in endpoint["children"]:
                         logger.info(
@@ -290,7 +288,7 @@ class CiscoClientISE(CiscoClientController):
                             for index, value in enumerate(
                                 endpoint_dict[endpoint["name"]]
                             ):
-                                if value.get("data").get("id") == id_:
+                                if self.get_id_value(value.get("data", {})) == id_:
                                     endpoint_dict[endpoint["name"]][index].setdefault(
                                         "children", {}
                                     )[

--- a/nac_collector/resources/endpoints/ise.yaml
+++ b/nac_collector/resources/endpoints/ise.yaml
@@ -98,6 +98,9 @@
   endpoint: /api/v1/policy/network-access/condition
 - name: network_access_dictionary
   endpoint: /api/v1/policy/network-access/dictionaries
+  children:
+  - name: network_access_dictionary_attribute
+    endpoint: /attribute
 - name: network_access_time_and_date_condition
   endpoint: /api/v1/policy/network-access/time-condition
 - name: network_device


### PR DESCRIPTION
## Summary

- Adds `network_access_dictionary_attribute` as a child endpoint of `network_access_dictionary` with relative path `/attribute`
- Fixes parent ID extraction for child endpoints to use `get_id_value()` instead of hardcoded `item["data"]["id"]`, supporting name-based resources like dictionaries

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: generated collector endpoint and fixed parent ID extraction
- **Human Oversight**: Code reviewed and approved by @ChristopherJHart

🤖 Generated with [Claude Code](https://claude.com/claude-code)