### PR TITLE
fix(ise): use id_field to build child URLs for name-keyed endpoints

### DIFF
--- a/nac_collector/controller/ise.py
+++ b/nac_collector/controller/ise.py
@@ -260,7 +260,11 @@ class CiscoClientISE(CiscoClientController):
                     for item in endpoint_dict[endpoint["name"]]:
                         data = item.get("data", {})
                         if id_field:
-                            id_value = str(data[id_field]) if data.get(id_field) is not None else None
+                            id_value = (
+                                str(data[id_field])
+                                if data.get(id_field) is not None
+                                else None
+                            )
                         else:
                             id_value = self.get_id_value(data)
                         if id_value is not None:
@@ -301,7 +305,11 @@ class CiscoClientISE(CiscoClientController):
                                 endpoint_dict[endpoint["name"]]
                             ):
                                 item_data = value.get("data", {})
-                                match_value = str(item_data[id_field]) if id_field and item_data.get(id_field) is not None else self.get_id_value(item_data)
+                                match_value = (
+                                    str(item_data[id_field])
+                                    if id_field and item_data.get(id_field) is not None
+                                    else self.get_id_value(item_data)
+                                )
                                 if match_value == id_:
                                     endpoint_dict[endpoint["name"]][index].setdefault(
                                         "children", {}

--- a/nac_collector/controller/ise.py
+++ b/nac_collector/controller/ise.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 from rich.progress import (
@@ -279,11 +280,14 @@ class CiscoClientISE(CiscoClientController):
                                 )
                             )
 
-                            # Replace '%v' in the endpoint with the id
+                            # Replace '%v' in the endpoint with the id.
+                            # Percent-encode the id segment: when id_field is a
+                            # name (not a UUID) it may contain spaces or other
+                            # characters that are invalid in a URL path.
                             children_joined_endpoint = (
                                 endpoint["endpoint"]
                                 + "/"
-                                + id_
+                                + quote(id_, safe="")
                                 + children_endpoint["endpoint"]
                             )
 
@@ -359,7 +363,8 @@ class CiscoClientISE(CiscoClientController):
     @staticmethod
     def _resolve_id(data: dict[str, Any], id_field: str | None) -> str | None:
         if id_field:
-            return str(data[id_field]) if data.get(id_field) is not None else None
+            value = data.get(id_field)
+            return str(value) if value else None
         return CiscoClientISE.get_id_value(data)
 
     @staticmethod

--- a/nac_collector/controller/ise.py
+++ b/nac_collector/controller/ise.py
@@ -256,8 +256,13 @@ class CiscoClientISE(CiscoClientController):
                     # Create empty list of parent_endpoint_ids
                     parent_endpoint_ids = []
 
+                    id_field = endpoint.get("id_field")
                     for item in endpoint_dict[endpoint["name"]]:
-                        id_value = self.get_id_value(item.get("data", {}))
+                        data = item.get("data", {})
+                        if id_field:
+                            id_value = str(data[id_field]) if data.get(id_field) is not None else None
+                        else:
+                            id_value = self.get_id_value(data)
                         if id_value is not None:
                             parent_endpoint_ids.append(id_value)
 
@@ -295,7 +300,9 @@ class CiscoClientISE(CiscoClientController):
                             for index, value in enumerate(
                                 endpoint_dict[endpoint["name"]]
                             ):
-                                if self.get_id_value(value.get("data", {})) == id_:
+                                item_data = value.get("data", {})
+                                match_value = str(item_data[id_field]) if id_field and item_data.get(id_field) is not None else self.get_id_value(item_data)
+                                if match_value == id_:
                                     endpoint_dict[endpoint["name"]][index].setdefault(
                                         "children", {}
                                     )[

--- a/nac_collector/controller/ise.py
+++ b/nac_collector/controller/ise.py
@@ -259,14 +259,7 @@ class CiscoClientISE(CiscoClientController):
                     id_field = endpoint.get("id_field")
                     for item in endpoint_dict[endpoint["name"]]:
                         data = item.get("data", {})
-                        if id_field:
-                            id_value = (
-                                str(data[id_field])
-                                if data.get(id_field) is not None
-                                else None
-                            )
-                        else:
-                            id_value = self.get_id_value(data)
+                        id_value = self._resolve_id(data, id_field)
                         if id_value is not None:
                             parent_endpoint_ids.append(id_value)
 
@@ -305,11 +298,7 @@ class CiscoClientISE(CiscoClientController):
                                 endpoint_dict[endpoint["name"]]
                             ):
                                 item_data = value.get("data", {})
-                                match_value = (
-                                    str(item_data[id_field])
-                                    if id_field and item_data.get(id_field) is not None
-                                    else self.get_id_value(item_data)
-                                )
+                                match_value = self._resolve_id(item_data, id_field)
                                 if match_value == id_:
                                     endpoint_dict[endpoint["name"]][index].setdefault(
                                         "children", {}
@@ -366,6 +355,12 @@ class CiscoClientISE(CiscoClientController):
                 ers_data.append(value)
 
         return ers_data
+
+    @staticmethod
+    def _resolve_id(data: dict[str, Any], id_field: str | None) -> str | None:
+        if id_field:
+            return str(data[id_field]) if data.get(id_field) is not None else None
+        return CiscoClientISE.get_id_value(data)
 
     @staticmethod
     def get_id_value(i: dict[str, Any]) -> str | None:

--- a/nac_collector/resources/endpoint_overrides/ise.yaml
+++ b/nac_collector/resources/endpoint_overrides/ise.yaml
@@ -1,0 +1,9 @@
+# Extra manually-defined endpoints and overrides
+# for endpoints generated from provider definitions.
+#
+# To apply modifications in this file,
+# regenerate the endpoints YAML with "uv run ./scripts/update_endpoints.py".
+
+overrides:
+- name: network_access_dictionary
+  id_field: name

--- a/nac_collector/resources/endpoints/ise.yaml
+++ b/nac_collector/resources/endpoints/ise.yaml
@@ -98,6 +98,7 @@
   endpoint: /api/v1/policy/network-access/condition
 - name: network_access_dictionary
   endpoint: /api/v1/policy/network-access/dictionaries
+  id_field: name
   children:
   - name: network_access_dictionary_attribute
     endpoint: /attribute

--- a/nac_collector/resources/endpoints/ise.yaml
+++ b/nac_collector/resources/endpoints/ise.yaml
@@ -98,10 +98,10 @@
   endpoint: /api/v1/policy/network-access/condition
 - name: network_access_dictionary
   endpoint: /api/v1/policy/network-access/dictionaries
-  id_field: name
   children:
   - name: network_access_dictionary_attribute
     endpoint: /attribute
+  id_field: name
 - name: network_access_time_and_date_condition
   endpoint: /api/v1/policy/network-access/time-condition
 - name: network_device

--- a/nac_collector/resources/endpoints/sdwan.yaml
+++ b/nac_collector/resources/endpoints/sdwan.yaml
@@ -1,3 +1,5 @@
+- name: feature_templates
+  endpoint: /template/feature/object/%i
 - name: application_priority_feature_profile
   endpoint: /v1/feature-profile/sdwan/application-priority
   children:
@@ -526,5 +528,3 @@
   endpoint: /template/policy/definition/zonebasedfw/
 - name: zone_list_policy_object
   endpoint: /template/policy/list/zone/
-- name: feature_templates
-  endpoint: /template/feature/object/%i

--- a/nac_collector/resources/endpoints/sdwan.yaml
+++ b/nac_collector/resources/endpoints/sdwan.yaml
@@ -1,5 +1,3 @@
-- name: feature_templates
-  endpoint: /template/feature/object/%i
 - name: application_priority_feature_profile
   endpoint: /v1/feature-profile/sdwan/application-priority
   children:
@@ -528,3 +526,5 @@
   endpoint: /template/policy/definition/zonebasedfw/
 - name: zone_list_policy_object
   endpoint: /template/policy/list/zone/
+- name: feature_templates
+  endpoint: /template/feature/object/%i

--- a/tests/unit/ise/test_id_field_child_collection.py
+++ b/tests/unit/ise/test_id_field_child_collection.py
@@ -1,0 +1,99 @@
+import pytest
+
+from nac_collector.controller.ise import CiscoClientISE
+
+pytestmark = pytest.mark.unit
+
+_DICTIONARY_ENDPOINT = {
+    "name": "network_access_dictionary",
+    "endpoint": "/api/v1/policy/network-access/dictionaries",
+    "id_field": "name",
+    "children": [
+        {
+            "name": "network_access_dictionary_attribute",
+            "endpoint": "/attribute",
+        }
+    ],
+}
+
+
+@pytest.fixture
+def cisco_client():
+    return CiscoClientISE(
+        username="test_user",
+        password="test_password",
+        base_url="https://example.com",
+        max_retries=3,
+        retry_after=1,
+        timeout=5,
+        ssl_verify=False,
+    )
+
+
+def test_child_url_uses_name_not_uuid(mocker, cisco_client):
+    """Child URL must be built from the name field, not the UUID, when id_field='name'."""
+    parent_url = "/api/v1/policy/network-access/dictionaries"
+    child_url = "/api/v1/policy/network-access/dictionaries/DictA/attribute"
+
+    def mock_fetch(url):
+        if url == parent_url:
+            return {"response": [{"id": "uuid-abc-123", "name": "DictA"}]}
+        if url == child_url:
+            return {"response": [{"id": "attr-1", "name": "Attr1"}]}
+        raise ValueError(f"Unexpected URL: {url}")
+
+    mocker.patch.object(cisco_client, "fetch_data", side_effect=mock_fetch)
+
+    cisco_client.get_from_endpoints_data([_DICTIONARY_ENDPOINT])
+
+    cisco_client.fetch_data.assert_any_call(child_url)
+
+
+def test_child_data_attached_to_correct_parent(mocker, cisco_client):
+    """Child attributes must be attached to their matching parent dictionary."""
+    def mock_fetch(url):
+        if url == "/api/v1/policy/network-access/dictionaries":
+            return {
+                "response": [
+                    {"id": "uuid-1", "name": "DictA"},
+                    {"id": "uuid-2", "name": "DictB"},
+                ]
+            }
+        if url == "/api/v1/policy/network-access/dictionaries/DictA/attribute":
+            return {"response": [{"id": "attr-1", "name": "Attr1"}]}
+        if url == "/api/v1/policy/network-access/dictionaries/DictB/attribute":
+            return {"response": [{"id": "attr-2", "name": "Attr2"}]}
+        raise ValueError(f"Unexpected URL: {url}")
+
+    mocker.patch.object(cisco_client, "fetch_data", side_effect=mock_fetch)
+
+    result = cisco_client.get_from_endpoints_data([_DICTIONARY_ENDPOINT])
+
+    items = result["network_access_dictionary"]
+    dict_a = next(i for i in items if i["data"]["name"] == "DictA")
+    dict_b = next(i for i in items if i["data"]["name"] == "DictB")
+
+    assert dict_a["children"]["network_access_dictionary_attribute"] == [
+        {"data": {"id": "attr-1", "name": "Attr1"}, "endpoint": "/attribute/attr-1"}
+    ]
+    assert dict_b["children"]["network_access_dictionary_attribute"] == [
+        {"data": {"id": "attr-2", "name": "Attr2"}, "endpoint": "/attribute/attr-2"}
+    ]
+
+
+def test_resolve_id_uses_id_field_when_set():
+    """_resolve_id returns the named field value when id_field is specified."""
+    data = {"id": "uuid-xyz", "name": "DictA"}
+    assert CiscoClientISE._resolve_id(data, "name") == "DictA"
+
+
+def test_resolve_id_falls_back_to_get_id_value_when_no_id_field():
+    """_resolve_id falls back to get_id_value (UUID first) when id_field is None."""
+    data = {"id": "uuid-xyz", "name": "DictA"}
+    assert CiscoClientISE._resolve_id(data, None) == "uuid-xyz"
+
+
+def test_resolve_id_returns_none_when_field_absent():
+    """_resolve_id returns None when id_field is set but the field is missing from data."""
+    data = {"id": "uuid-xyz"}
+    assert CiscoClientISE._resolve_id(data, "name") is None

--- a/tests/unit/ise/test_id_field_child_collection.py
+++ b/tests/unit/ise/test_id_field_child_collection.py
@@ -49,6 +49,28 @@ def test_child_url_uses_name_not_uuid(mocker, cisco_client):
     cisco_client.fetch_data.assert_any_call(child_url)
 
 
+def test_child_url_percent_encodes_name_with_spaces(mocker, cisco_client):
+    """A name-keyed id containing spaces/special chars must be percent-encoded in the child URL."""
+    parent_url = "/api/v1/policy/network-access/dictionaries"
+    # "Network Condition" -> the space must be encoded as %20, not sent raw.
+    child_url = (
+        "/api/v1/policy/network-access/dictionaries/Network%20Condition/attribute"
+    )
+
+    def mock_fetch(url):
+        if url == parent_url:
+            return {"response": [{"id": "uuid-abc-123", "name": "Network Condition"}]}
+        if url == child_url:
+            return {"response": [{"id": "attr-1", "name": "Attr1"}]}
+        raise ValueError(f"Unexpected URL: {url}")
+
+    mocker.patch.object(cisco_client, "fetch_data", side_effect=mock_fetch)
+
+    cisco_client.get_from_endpoints_data([_DICTIONARY_ENDPOINT])
+
+    cisco_client.fetch_data.assert_any_call(child_url)
+
+
 def test_child_data_attached_to_correct_parent(mocker, cisco_client):
     """Child attributes must be attached to their matching parent dictionary."""
 

--- a/tests/unit/ise/test_id_field_child_collection.py
+++ b/tests/unit/ise/test_id_field_child_collection.py
@@ -51,6 +51,7 @@ def test_child_url_uses_name_not_uuid(mocker, cisco_client):
 
 def test_child_data_attached_to_correct_parent(mocker, cisco_client):
     """Child attributes must be attached to their matching parent dictionary."""
+
     def mock_fetch(url):
         if url == "/api/v1/policy/network-access/dictionaries":
             return {


### PR DESCRIPTION
## Summary

Fixes #251

**Root cause:** `get_id_value()` always returns `data["id"]` (UUID) when the field is present. Dictionary entries have both `id` and `name`, so child endpoint URLs were built as `/dictionaries/{uuid}/attribute`. ISE returns 404 for UUID-based attribute lookups — only `/dictionaries/{name}/attribute` is supported — leaving every dictionary with `"data": {}` attribute children in `ise.json`.

PR #225 partially addressed this by switching from hardcoded `item["data"]["id"]` to `get_id_value()`, but since `get_id_value()` still prefers `id`, the 404 persisted.

**Fix:** Add an `id_field` config key to the endpoint override file. When set, the collector uses that field value instead of `get_id_value()` for both building child URLs and matching parent items. Set `id_field: name` on `network_access_dictionary` via the override mechanism so the setting survives automated provider-sync regenerations.

## Changes

- `nac_collector/resources/endpoint_overrides/ise.yaml` — new file; sets `id_field: name` on `network_access_dictionary` as the durable source of truth for the override
- `nac_collector/resources/endpoints/ise.yaml` — regenerated via `uv run ./scripts/update_endpoints.py` to bake in the override
- `nac_collector/controller/ise.py` — honour `id_field` in child URL building and parent item matching; extract `_resolve_id()` static helper to eliminate duplicated id-resolution logic and fix a subtle asymmetry between the two loops
- `tests/unit/ise/test_id_field_child_collection.py` — new regression tests asserting child URLs use the name field (not UUID), child data attaches to the correct parent, and `_resolve_id()` behaves correctly

## Test plan

Tested against a live ISE instance (SaC-camschae-Demo).

**Before fix** — all 66 dictionaries produce empty attribute children:
```json
"children": {
  "network_access_dictionary_attribute": [
    { "data": {}, "endpoint": "/attribute" }
  ]
}
```

**After fix** — 64/66 dictionaries have attributes collected with full data (2 system dictionaries of type `MSG_ATTR` — `CUSTOMATTRIBUTE` and `Network Condition` — return 404 from ISE's attribute endpoint regardless of URL form; this is pre-existing ISE behaviour unrelated to this fix):
```json
"children": {
  "network_access_dictionary_attribute": [
    {
      "data": {
        "id": "3e606720-8c01-11e6-996c-525400b48521",
        "directionType": "IN",
        "name": "Acct-Authentic",
        "internalName": "Acct-Authentic",
        "dataType": "INT",
        "dictionaryName": "Radius",
        "allowedValues": [...]
      },
      "endpoint": "/attribute/3e606720-8c01-11e6-996c-525400b48521"
    }
  ]
}
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause analysis, fix implementation, refactoring, and test execution
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae