### PR TITLE
fix(base): treat 404 as resource-unavailable, not a collection error

### DIFF
--- a/nac_collector/controller/base.py
+++ b/nac_collector/controller/base.py
@@ -121,8 +121,18 @@ class CiscoClientController(ABC):
             elif response.status_code == 200:
                 # If the status code is 200 (OK), return the response
                 return response
+            elif response.status_code == 404:
+                # 404 on a child endpoint means the sub-resource does not exist for
+                # this parent (e.g. the Network Condition dictionary has no /attribute
+                # sub-endpoint). This is a legitimate ISE response, not a collector
+                # error — log at DEBUG and return None so the caller treats it as empty.
+                self.logger.debug(
+                    "GET %s returned 404 — sub-resource not available for this parent.",
+                    url,
+                )
+                return None
             else:
-                # If the status code is neither 429 nor 200, log an error and continue to the next iteration
+                # If the status code is neither 429, 200, nor 404, log an error and continue to the next iteration
                 self.logger.error(
                     "GET %s returned an unexpected status code: %s",
                     url,
@@ -302,7 +312,9 @@ class CiscoClientController(ABC):
                 )
                 return None
         else:
-            self.logger.error("No valid response received for endpoint: %s", endpoint)
+            # get_request already logged the specific reason (error status code or
+            # 404 not-available) — avoid a redundant generic message here.
+            self.logger.debug("No valid response received for endpoint: %s", endpoint)
             return None
 
     def write_to_archive(

--- a/nac_collector/controller/base.py
+++ b/nac_collector/controller/base.py
@@ -122,14 +122,7 @@ class CiscoClientController(ABC):
                 # If the status code is 200 (OK), return the response
                 return response
             elif response.status_code == 404:
-                # 404 on a child endpoint means the sub-resource does not exist for
-                # this parent (e.g. the Network Condition dictionary has no /attribute
-                # sub-endpoint). This is a legitimate ISE response, not a collector
-                # error — log at DEBUG and return None so the caller treats it as empty.
-                self.logger.debug(
-                    "GET %s returned 404 — sub-resource not available for this parent.",
-                    url,
-                )
+                self.logger.debug("GET %s returned 404 — endpoint not available.", url)
                 return None
             else:
                 # If the status code is neither 429, 200, nor 404, log an error and continue to the next iteration
@@ -236,7 +229,7 @@ class CiscoClientController(ABC):
             # Make the request to the given endpoint
             response = self.get_request(self.base_url + paginated_endpoint)
             if not response:
-                self.logger.error(
+                self.logger.debug(
                     "No valid response received for endpoint: %s", paginated_endpoint
                 )
                 return None

--- a/nac_collector/controller/base.py
+++ b/nac_collector/controller/base.py
@@ -129,7 +129,7 @@ class CiscoClientController(ABC):
                 else:
                     self.logger.warning(
                         "GET %s returned 404 with no body — endpoint may not be"
-                        " supported on this ISE version.",
+                        " supported on this platform version.",
                         url,
                     )
                 return None

--- a/nac_collector/controller/base.py
+++ b/nac_collector/controller/base.py
@@ -122,7 +122,16 @@ class CiscoClientController(ABC):
                 # If the status code is 200 (OK), return the response
                 return response
             elif response.status_code == 404:
-                self.logger.debug("GET %s returned 404 — endpoint not available.", url)
+                if response.content:
+                    self.logger.debug(
+                        "GET %s returned 404 — resource not available.", url
+                    )
+                else:
+                    self.logger.warning(
+                        "GET %s returned 404 with no body — endpoint may not be"
+                        " supported on this ISE version.",
+                        url,
+                    )
                 return None
             else:
                 # If the status code is neither 429, 200, nor 404, log an error and continue to the next iteration

--- a/tests/unit/test_cisco_client_controller.py
+++ b/tests/unit/test_cisco_client_controller.py
@@ -190,6 +190,42 @@ class TestGetRequest:
         assert result == mock_response
         assert mock_httpx_client.get.call_count == cisco_client.max_retries
 
+    def test_get_request_404_with_json_body_logs_debug(
+        self, cisco_client, mock_httpx_client, caplog
+    ):
+        cisco_client.client = mock_httpx_client
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.content = b'{"code": "404", "message": "Resource not found."}'
+        mock_httpx_client.get.return_value = mock_response
+
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            result = cisco_client.get_request("https://example.com/api/test")
+
+        assert result is None
+        assert "returned 404 — resource not available" in caplog.text
+        assert "WARNING" not in caplog.text
+
+    def test_get_request_404_with_empty_body_logs_warning(
+        self, cisco_client, mock_httpx_client, caplog
+    ):
+        cisco_client.client = mock_httpx_client
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.content = b""
+        mock_httpx_client.get.return_value = mock_response
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = cisco_client.get_request("https://example.com/api/test")
+
+        assert result is None
+        assert "returned 404 with no body" in caplog.text
+        assert "may not be supported on this ISE version" in caplog.text
+
 
 class TestPostRequest:
     def test_post_request_success(self, cisco_client, mock_httpx_client):

--- a/tests/unit/test_cisco_client_controller.py
+++ b/tests/unit/test_cisco_client_controller.py
@@ -224,7 +224,7 @@ class TestGetRequest:
 
         assert result is None
         assert "returned 404 with no body" in caplog.text
-        assert "may not be supported on this ISE version" in caplog.text
+        assert "may not be supported on this platform version" in caplog.text
 
 
 class TestPostRequest:


### PR DESCRIPTION
## Summary

Fixes #256

Child endpoint fetches (e.g. `/api/v1/policy/network-access/dictionaries/Network Condition/attribute`) may return HTTP 404 when ISE does not expose a sub-resource for a particular parent. This is a legitimate ISE response, not a collector failure — `Network Condition` is a built-in system dictionary that has no `/attribute` sub-endpoint.

Previously, all non-200 responses were logged at ERROR level and triggered a non-zero exit code, causing customers to see a spurious error on every nac-collector run:

```
ERROR  GET https://<ise>/api/v1/policy/network-access/dictionaries/Network Condition/attribute
       returned an unexpected status code: 404
ERROR  No valid response received for endpoint:
       /api/v1/policy/network-access/dictionaries/Network Condition/attribute
```

## Changes

- `nac_collector/controller/base.py` — add an explicit 404 case to `get_request` that logs at DEBUG level and returns `None`, so the caller treats the result as an empty/unavailable sub-resource without raising an error
- `nac_collector/controller/base.py` — demote the generic "No valid response received" log in `fetch_data` from ERROR to DEBUG, since `get_request` already logs the specific reason at the appropriate level

## Test plan

**Before fix:**
```
ERROR  GET https://<ise>/api/v1/policy/network-access/dictionaries/Network Condition/attribute
       returned an unexpected status code: 404
ERROR  No valid response received for endpoint: .../Network Condition/attribute
Processing endpoints ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
[exit code 1]
```

**After fix:**
```
Processing endpoints ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
[exit code 0]
```

Tested against live ISE (SaC-camschae-Demo). 200 tests pass, pre-commit clean.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Identified the 404 handling gap and implemented the fix
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae