### PR TITLE
fix(meraki): compatibility fixes for Meraki SDK v4.x

### DIFF
--- a/nac_collector/controller/meraki.py
+++ b/nac_collector/controller/meraki.py
@@ -4,7 +4,11 @@ import os
 from typing import Any
 
 from meraki.exceptions import APIError
-from meraki.session.async_ import AsyncRestSession
+
+try:
+    from meraki.session.async_ import AsyncRestSession  # SDK v4.x+
+except ImportError:
+    from meraki.aio.rest_session import AsyncRestSession  # SDK v3.x
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,

--- a/nac_collector/controller/meraki.py
+++ b/nac_collector/controller/meraki.py
@@ -3,8 +3,8 @@ import logging
 import os
 from typing import Any
 
-from meraki.session.async_ import AsyncRestSession
 from meraki.exceptions import APIError
+from meraki.session.async_ import AsyncRestSession
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,

--- a/nac_collector/controller/meraki.py
+++ b/nac_collector/controller/meraki.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import Any
 
-from meraki.aio.rest_session import AsyncRestSession
+from meraki.session.async_ import AsyncRestSession
 from meraki.exceptions import AsyncAPIError
 from rich.progress import (
     BarColumn,

--- a/nac_collector/controller/meraki.py
+++ b/nac_collector/controller/meraki.py
@@ -4,7 +4,7 @@ import os
 from typing import Any
 
 from meraki.session.async_ import AsyncRestSession
-from meraki.exceptions import AsyncAPIError
+from meraki.exceptions import APIError
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -446,7 +446,7 @@ class CiscoClientMERAKI(CiscoClientController):
                 await asyncio.sleep(self.request_throttle_delay)
             data = await self.session.get_pages(metadata, uri)
             return data, None
-        except AsyncAPIError as e:
+        except APIError as e:
             return None, {
                 "status_code": e.status,
                 "message": e.message,

--- a/nac_collector/controller/meraki.py
+++ b/nac_collector/controller/meraki.py
@@ -9,6 +9,13 @@ try:
     from meraki.session.async_ import AsyncRestSession  # SDK v4.x+
 except ImportError:
     from meraki.aio.rest_session import AsyncRestSession  # SDK v3.x
+
+# In SDK v3.x AsyncAPIError is unrelated to APIError; in v4.x it is a deprecated subclass.
+# Import it so we can catch it explicitly when running against v3.x.
+try:
+    from meraki.exceptions import AsyncAPIError
+except ImportError:
+    AsyncAPIError = APIError  # type: ignore[assignment,misc]
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -450,7 +457,7 @@ class CiscoClientMERAKI(CiscoClientController):
                 await asyncio.sleep(self.request_throttle_delay)
             data = await self.session.get_pages(metadata, uri)
             return data, None
-        except APIError as e:
+        except (APIError, AsyncAPIError) as e:
             return None, {
                 "status_code": e.status,
                 "message": e.message,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "rich>=14.1.0",
     "gitpython>=3.1.45",
     "httpx>=0.28.1",
-    "meraki>=2.2.0,<=3.3.0",
+    "meraki>=2.2.0",
     "ruamel.yaml>=0.18.15",
     "tinydb>=4.8.2",
     "paramiko>=3.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -21,15 +21,15 @@ name = "aiohttp"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
+    { name = "aiohappyeyeballs", marker = "python_full_version < '3.11'" },
+    { name = "aiosignal", marker = "python_full_version < '3.11'" },
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "yarl" },
+    { name = "attrs", marker = "python_full_version < '3.11'" },
+    { name = "frozenlist", marker = "python_full_version < '3.11'" },
+    { name = "multidict", marker = "python_full_version < '3.11'" },
+    { name = "propcache", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "yarl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
@@ -158,8 +158,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "frozenlist", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -1213,19 +1213,18 @@ wheels = [
 
 [[package]]
 name = "meraki"
-version = "3.2.0"
+version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version >= '3.11' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "httpx", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/30/152e4f4e3aed1e03fc38c05433cc15ecae32de602eaf2d6b21a3800ae3c5/meraki-3.2.0.tar.gz", hash = "sha256:866ef4d9910095ff74cf6780ede682a5a5d2a442cc9a641c09981b95e426696f", size = 336454, upload-time = "2026-06-04T07:19:27.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/11/ecc5b2f94bd955102c359c7faadb5859b89c5a4e6f6093016a0719d018a7/meraki-4.3.0.tar.gz", hash = "sha256:c7ecdf4711529cb575eb5480ba504f860a7f73685c2c8518d3366933c4953666", size = 355173, upload-time = "2026-07-09T04:12:07.337Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/c3/597aff895afc4d8cb15ad14ec30162d42e20536366f5d38b6fd9ec3dbe2c/meraki-3.2.0-py3-none-any.whl", hash = "sha256:14aca05a8aec79f3dec2f40bd3dcbfdb4ef72b0b052ddd0014ed8802f6d67e99", size = 381123, upload-time = "2026-06-04T07:19:26.271Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/83/6614b59109f7984c87a5318b15337466db1725d7aaee74a4eb43c6e6ef2d/meraki-4.3.0-py3-none-any.whl", hash = "sha256:182e2af96eb84569b829999540b149a55519bb62dcc6d738a88345df2b4afbb8", size = 400144, upload-time = "2026-07-09T04:12:05.618Z" },
 ]
 
 [[package]]
@@ -1442,7 +1441,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "httpx" },
     { name = "meraki", version = "2.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "meraki", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "meraki", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "paramiko" },
     { name = "rich" },
     { name = "ruamel-yaml" },
@@ -1467,7 +1466,7 @@ requires-dist = [
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.8.6" },
     { name = "gitpython", specifier = ">=3.1.45" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "meraki", specifier = ">=2.2.0,<=3.3.0" },
+    { name = "meraki", specifier = ">=2.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17.1" },
     { name = "paramiko", specifier = ">=3.5.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3.0" },
@@ -1875,10 +1874,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version < '3.11'" },
+    { name = "charset-normalizer", marker = "python_full_version < '3.11'" },
+    { name = "idna", marker = "python_full_version < '3.11'" },
+    { name = "urllib3", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -2109,9 +2108,9 @@ name = "yarl"
 version = "1.24.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
+    { name = "idna", marker = "python_full_version < '3.11'" },
+    { name = "multidict", marker = "python_full_version < '3.11'" },
+    { name = "propcache", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
 wheels = [


### PR DESCRIPTION
## Summary

This PR makes the Meraki controller compatible with both SDK v3.x and v4.x, and upgrades the lockfile to resolve meraki v4.3.0 on Python ≥3.11. It supersedes the workaround in #262 which capped the SDK at `<=3.3.0`.

### Changes

- **Import path**: `AsyncRestSession` moved from `meraki.aio.rest_session` (v3.x) to `meraki.session.async_` (v4.x). A `try/except ImportError` fallback handles both.
- **Exception handling**: In SDK v3.x, `AsyncAPIError` and `APIError` are unrelated classes — `AsyncAPIError` does **not** inherit from `APIError`. The async session raises `AsyncAPIError`, so `except APIError` silently swallows all errors on v3.x. Fixed by importing `AsyncAPIError` with its own fallback and catching `(APIError, AsyncAPIError)`.
- **Dependency bound**: Removed `<=3.3.0` upper bound from `pyproject.toml`.
- **Lockfile**: Upgraded to meraki v4.3.0 on Python ≥3.11. meraki v4.x switched its HTTP backend from `aiohttp`+`requests` to `httpx` (already a direct dependency), so `aiohttp`, `requests`, and their transitive dependencies are now correctly scoped to Python <3.11 only in the lockfile.

### Compatibility matrix

| SDK version | `AsyncRestSession` import | Exception caught |
|---|---|---|
| v3.x (Python <3.11) | `meraki.aio.rest_session` (fallback) | `AsyncAPIError` |
| v4.x (Python ≥3.11) | `meraki.session.async_` | `APIError` (also catches `AsyncAPIError` as a deprecated subclass) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)