### PR TITLE
fix:sdwan remove duplicate policy_object_feature_profile_parcels endpoint

### DIFF
--- a/nac_collector/resources/endpoint_overrides/sdwan.yaml
+++ b/nac_collector/resources/endpoint_overrides/sdwan.yaml
@@ -1,0 +1,12 @@
+# Extra manually-defined endpoints and overrides
+# for endpoints generated from provider definitions.
+#
+# To apply modifications in this file,
+# regenerate the endpoints YAML with "uv run ./scripts/update_endpoints.py".
+
+remove_endpoints:
+# terraform-provider-sdwan's policy_object_feature_profile_parcels.yaml is a
+# data-source-only definition added alongside the existing policy_object_feature_profile resource, at the same
+# base endpoint (/v1/feature-profile/sdwan/policy-object). 
+# policy_object_feature_profile already covers the same children, so drop the duplicate data-source-only entry.
+- policy_object_feature_profile_parcels

--- a/nac_collector/resources/endpoints/sdwan.yaml
+++ b/nac_collector/resources/endpoints/sdwan.yaml
@@ -1,15 +1,5 @@
-- name: advanced_inspection_profile_policy_definition
-  endpoint: /template/policy/definition/advancedinspectionprofile/
-- name: advanced_malware_protection_policy_definition
-  endpoint: /template/policy/definition/advancedMalwareProtection/
-- name: allow_url_list_policy_object
-  endpoint: /template/policy/list/urlwhitelist/
-- name: app_probe_class_policy_object
-  endpoint: /template/policy/list/appprobe/
-- name: application_aware_routing_policy_definition
-  endpoint: /template/policy/definition/approute/
-- name: application_list_policy_object
-  endpoint: /template/policy/list/app/
+- name: feature_templates
+  endpoint: /template/feature/object/%i
 - name: application_priority_feature_profile
   endpoint: /v1/feature-profile/sdwan/application-priority
   children:
@@ -19,50 +9,11 @@
     endpoint: /qos-policy
   - name: application_priority_traffic_policy
     endpoint: /traffic-policy
-- name: as_path_list_policy_object
-  endpoint: /template/policy/list/aspath/
-- name: block_url_list_policy_object
-  endpoint: /template/policy/list/urlblacklist/
-- name: centralized_policy
-  endpoint: /template/policy/vsmart/
-- name: cflowd_policy_definition
-  endpoint: /template/policy/definition/cflowd/
-- name: class_map_policy_object
-  endpoint: /template/policy/list/class/
-- name: cli_feature_profile
-  endpoint: /v1/feature-profile/sdwan/cli
-  children:
-  - name: cli_config_feature
-    endpoint: /config
-- name: cli_device_template
-  endpoint: /template/device/
-- name: cloud_provider_settings
-  endpoint: /settings/configuration/cloudProviderSetting
-- name: color_list_policy_object
-  endpoint: /template/policy/list/color/
-- name: configuration_group
-  endpoint: /v1/config-group/
-- name: custom_application
-  endpoint: /template/policy/customapp/
-- name: custom_control_topology_policy_definition
-  endpoint: /template/policy/definition/control/
-- name: data_fqdn_prefix_list_policy_object
-  endpoint: /template/policy/list/fqdn/
-- name: data_ipv4_prefix_list_policy_object
-  endpoint: /template/policy/list/dataprefix/
-- name: data_ipv6_prefix_list_policy_object
-  endpoint: /template/policy/list/dataipv6prefix/
-- name: device
-  endpoint: /device
 - name: dns_security_feature_profile
   endpoint: /v1/feature-profile/sdwan/dns-security
   children:
   - name: dns_security
     endpoint: /dns
-- name: dns_security_policy_definition
-  endpoint: /template/policy/definition/dnssecurity/
-- name: domain_list_policy_object
-  endpoint: /template/policy/list/localdomain/
 - name: embedded_security_feature_profile
   endpoint: /v1/feature-profile/sdwan/embedded-security
   children:
@@ -70,42 +21,6 @@
     endpoint: /policy
   - name: embedded_security_ngfw
     endpoint: /unified/ngfirewall
-- name: expanded_community_list_policy_object
-  endpoint: /template/policy/list/expandedcommunity/
-- name: extended_community_list_policy_object
-  endpoint: /template/policy/list/extcommunity/
-- name: feature_device_template
-  endpoint: /template/device/object/%i
-- name: geo_location_list_policy_object
-  endpoint: /template/policy/list/geolocation/
-- name: hub_and_spoke_topology_policy_definition
-  endpoint: /template/policy/definition/hubandspoke/
-- name: intrusion_prevention_policy_definition
-  endpoint: /template/policy/definition/intrusionprevention/
-- name: ips_signature_list_policy_object
-  endpoint: /template/policy/list/ipssignature/
-- name: ipv4_acl_policy_definition
-  endpoint: /template/policy/definition/acl/
-- name: ipv4_device_acl_policy_definition
-  endpoint: /template/policy/definition/deviceaccesspolicy/
-- name: ipv4_prefix_list_policy_object
-  endpoint: /template/policy/list/prefix/
-- name: ipv6_acl_policy_definition
-  endpoint: /template/policy/definition/aclv6/
-- name: ipv6_device_acl_policy_definition
-  endpoint: /template/policy/definition/deviceaccesspolicyv6/
-- name: ipv6_prefix_list_policy_object
-  endpoint: /template/policy/list/ipv6prefix/
-- name: local_application_list_policy_object
-  endpoint: /template/policy/list/localapp/
-- name: localized_policy
-  endpoint: /template/policy/vedge/
-- name: mesh_topology_policy_definition
-  endpoint: /template/policy/definition/mesh/
-- name: mirror_policy_object
-  endpoint: /template/policy/list/mirror/
-- name: object_group_policy_definition
-  endpoint: /template/policy/definition/securitygroup/
 - name: other_feature_profile
   endpoint: /v1/feature-profile/sdwan/other
   children:
@@ -115,10 +30,6 @@
     endpoint: /trustsec
   - name: other_ucse
     endpoint: /ucse
-- name: policer_policy_object
-  endpoint: /template/policy/list/policer/
-- name: policy_group
-  endpoint: /v1/policy-group/
 - name: policy_object_feature_profile
   endpoint: /v1/feature-profile/sdwan/policy-object
   children:
@@ -199,6 +110,12 @@
 - name: service_feature_profile
   endpoint: /v1/feature-profile/sdwan/service
   children:
+  - name: service_dhcp_server
+    endpoint: /dhcp-server
+  - name: service_ipv4_acl
+    endpoint: /ipv4-acl
+  - name: service_ipv6_acl
+    endpoint: /ipv6-acl
   - name: service_lan_vpn
     endpoint: /lan/vpn
     children:
@@ -211,6 +128,8 @@
         endpoint: /tracker
       - name: service_lan_vpn_ethernet_interface_feature_associate_tracker_group
         endpoint: /trackergroup
+    - name: service_lan_vpn_interface_gre
+      endpoint: /interface/gre
     - name: service_lan_vpn_interface_ipsec
       endpoint: /interface/ipsec
       children:
@@ -233,14 +152,6 @@
       endpoint: /routing/ospfv3/ipv4
     - name: service_lan_vpn_feature_associate_routing_ospfv3_ipv6
       endpoint: /routing/ospfv3/ipv6
-    - name: service_lan_vpn_interface_gre
-      endpoint: /interface/gre
-  - name: service_dhcp_server
-    endpoint: /dhcp-server
-  - name: service_ipv4_acl
-    endpoint: /ipv4-acl
-  - name: service_ipv6_acl
-    endpoint: /ipv6-acl
   - name: service_multicast
     endpoint: /routing/multicast
   - name: service_object_tracker
@@ -267,12 +178,6 @@
     endpoint: /trackergroup
   - name: service_wireless_lan
     endpoint: /wirelesslan
-- name: sig_security_feature_profile
-  endpoint: /v1/feature-profile/sdwan/sig-security
-- name: site_list_policy_object
-  endpoint: /template/policy/list/site/
-- name: sla_class_policy_object
-  endpoint: /template/policy/list/sla/
 - name: sse_feature_profile
   endpoint: /v1/feature-profile/sdwan/sse
   children:
@@ -280,8 +185,6 @@
     endpoint: /cisco
   - name: sse_zscaler
     endpoint: /zscaler
-- name: standard_community_list_policy_object
-  endpoint: /template/policy/list/community/
 - name: system_feature_profile
   endpoint: /v1/feature-profile/sdwan/system
   children:
@@ -319,12 +222,6 @@
     endpoint: /security
   - name: system_snmp
     endpoint: /snmp
-- name: tag
-  endpoint: /v1/tags
-- name: tloc_list_policy_object
-  endpoint: /template/policy/list/tloc/
-- name: tls_ssl_profile_policy_definition
-  endpoint: /template/policy/definition/sslutdprofile/
 - name: topology_feature_profile
   endpoint: /v1/feature-profile/sdwan/topology
   children:
@@ -334,58 +231,9 @@
     endpoint: /hubspoke
   - name: topology_mesh
     endpoint: /mesh
-- name: topology_group
-  endpoint: /v1/topology-group/
-- name: traffic_data_policy_definition
-  endpoint: /template/policy/definition/data/
 - name: transport_feature_profile
   endpoint: /v1/feature-profile/sdwan/transport
   children:
-  - name: transport_wan_vpn
-    endpoint: /wan/vpn
-    children:
-    - name: transport_wan_vpn_feature_associate_routing_bgp
-      endpoint: /routing/bgp
-    - name: transport_wan_vpn_feature_associate_routing_ospf
-      endpoint: /routing/ospf
-    - name: transport_wan_vpn_feature_associate_routing_ospfv3_ipv4
-      endpoint: /routing/ospfv3/ipv4
-    - name: transport_wan_vpn_feature_associate_routing_ospfv3_ipv6
-      endpoint: /routing/ospfv3/ipv6
-    - name: transport_wan_vpn_interface_cellular
-      endpoint: /interface/cellular
-      children:
-      - name: transport_wan_vpn_interface_cellular_feature_associate_tracker
-        endpoint: /tracker
-      - name: 
-          transport_wan_vpn_interface_cellular_feature_associate_tracker_group
-        endpoint: /tracker
-    - name: transport_wan_vpn_interface_ethernet
-      endpoint: /interface/ethernet
-      children:
-      - name: 
-          transport_wan_vpn_interface_ethernet_feature_associate_ipv6_tracker
-        endpoint: /ipv6-tracker
-      - name: 
-          transport_wan_vpn_interface_ethernet_feature_associate_ipv6_tracker_group
-        endpoint: /ipv6-trackergroup
-      - name: transport_wan_vpn_interface_ethernet_feature_associate_tracker
-        endpoint: /tracker
-      - name: 
-          transport_wan_vpn_interface_ethernet_feature_associate_tracker_group
-        endpoint: /trackergroup
-    - name: transport_wan_vpn_interface_gre
-      endpoint: /interface/gre
-      children:
-      - name: transport_wan_vpn_interface_gre_feature_associate_tracker
-        endpoint: /tracker
-    - name: transport_wan_vpn_interface_ipsec
-      endpoint: /interface/ipsec
-      children:
-      - name: transport_wan_vpn_interface_ipsec_feature_associate_tracker
-        endpoint: /tracker
-    - name: transport_wan_vpn_interface_t1_e1_serial
-      endpoint: /interface/serial
   - name: transport_cellular_controller
     endpoint: /cellular-controller
   - name: transport_cellular_profile
@@ -421,6 +269,178 @@
     endpoint: /tracker
   - name: transport_tracker_group
     endpoint: /trackergroup
+  - name: transport_wan_vpn
+    endpoint: /wan/vpn
+    children:
+    - name: transport_wan_vpn_interface_cellular
+      endpoint: /interface/cellular
+      children:
+      - name: transport_wan_vpn_interface_cellular_feature_associate_tracker
+        endpoint: /tracker
+      - name: 
+          transport_wan_vpn_interface_cellular_feature_associate_tracker_group
+        endpoint: /tracker
+    - name: transport_wan_vpn_interface_ethernet
+      endpoint: /interface/ethernet
+      children:
+      - name: 
+          transport_wan_vpn_interface_ethernet_feature_associate_ipv6_tracker
+        endpoint: /ipv6-tracker
+      - name: 
+          transport_wan_vpn_interface_ethernet_feature_associate_ipv6_tracker_group
+        endpoint: /ipv6-trackergroup
+      - name: transport_wan_vpn_interface_ethernet_feature_associate_tracker
+        endpoint: /tracker
+      - name: 
+          transport_wan_vpn_interface_ethernet_feature_associate_tracker_group
+        endpoint: /trackergroup
+    - name: transport_wan_vpn_interface_gre
+      endpoint: /interface/gre
+      children:
+      - name: transport_wan_vpn_interface_gre_feature_associate_tracker
+        endpoint: /tracker
+    - name: transport_wan_vpn_interface_ipsec
+      endpoint: /interface/ipsec
+      children:
+      - name: transport_wan_vpn_interface_ipsec_feature_associate_tracker
+        endpoint: /tracker
+    - name: transport_wan_vpn_interface_t1_e1_serial
+      endpoint: /interface/serial
+    - name: transport_wan_vpn_feature_associate_routing_bgp
+      endpoint: /routing/bgp
+    - name: transport_wan_vpn_feature_associate_routing_ospf
+      endpoint: /routing/ospf
+    - name: transport_wan_vpn_feature_associate_routing_ospfv3_ipv4
+      endpoint: /routing/ospfv3/ipv4
+    - name: transport_wan_vpn_feature_associate_routing_ospfv3_ipv6
+      endpoint: /routing/ospfv3/ipv6
+- name: advanced_inspection_profile_policy_definition
+  endpoint: /template/policy/definition/advancedinspectionprofile/
+- name: advanced_malware_protection_policy_definition
+  endpoint: /template/policy/definition/advancedMalwareProtection/
+- name: allow_url_list_policy_object
+  endpoint: /template/policy/list/urlwhitelist/
+- name: app_probe_class_policy_object
+  endpoint: /template/policy/list/appprobe/
+- name: application_aware_routing_policy_definition
+  endpoint: /template/policy/definition/approute/
+- name: application_list_policy_object
+  endpoint: /template/policy/list/app/
+- name: as_path_list_policy_object
+  endpoint: /template/policy/list/aspath/
+- name: block_url_list_policy_object
+  endpoint: /template/policy/list/urlblacklist/
+- name: centralized_policy
+  endpoint: /template/policy/vsmart/
+- name: cflowd_policy_definition
+  endpoint: /template/policy/definition/cflowd/
+- name: class_map_policy_object
+  endpoint: /template/policy/list/class/
+- name: cli_feature_profile
+  endpoint: /v1/feature-profile/sdwan/cli
+  children:
+  - name: cli_config_feature
+    endpoint: /config
+- name: cli_device_template
+  endpoint: /template/device/
+- name: cloud_provider_settings
+  endpoint: /settings/configuration/cloudProviderSetting
+- name: color_list_policy_object
+  endpoint: /template/policy/list/color/
+- name: configuration_group
+  endpoint: /v1/config-group/
+- name: custom_application
+  endpoint: /template/policy/customapp/
+- name: custom_control_topology_policy_definition
+  endpoint: /template/policy/definition/control/
+- name: data_fqdn_prefix_list_policy_object
+  endpoint: /template/policy/list/fqdn/
+- name: data_ipv4_prefix_list_policy_object
+  endpoint: /template/policy/list/dataprefix/
+- name: data_ipv6_prefix_list_policy_object
+  endpoint: /template/policy/list/dataipv6prefix/
+- name: device
+  endpoint: /device
+- name: dns_security_policy_definition
+  endpoint: /template/policy/definition/dnssecurity/
+- name: domain_list_policy_object
+  endpoint: /template/policy/list/localdomain/
+- name: expanded_community_list_policy_object
+  endpoint: /template/policy/list/expandedcommunity/
+- name: extended_community_list_policy_object
+  endpoint: /template/policy/list/extcommunity/
+- name: feature_device_template
+  endpoint: /template/device/object/%i
+- name: geo_location_list_policy_object
+  endpoint: /template/policy/list/geolocation/
+- name: hub_and_spoke_topology_policy_definition
+  endpoint: /template/policy/definition/hubandspoke/
+- name: intrusion_prevention_policy_definition
+  endpoint: /template/policy/definition/intrusionprevention/
+- name: ips_signature_list_policy_object
+  endpoint: /template/policy/list/ipssignature/
+- name: ipv4_acl_policy_definition
+  endpoint: /template/policy/definition/acl/
+- name: ipv4_device_acl_policy_definition
+  endpoint: /template/policy/definition/deviceaccesspolicy/
+- name: ipv4_prefix_list_policy_object
+  endpoint: /template/policy/list/prefix/
+- name: ipv6_acl_policy_definition
+  endpoint: /template/policy/definition/aclv6/
+- name: ipv6_device_acl_policy_definition
+  endpoint: /template/policy/definition/deviceaccesspolicyv6/
+- name: ipv6_prefix_list_policy_object
+  endpoint: /template/policy/list/ipv6prefix/
+- name: local_application_list_policy_object
+  endpoint: /template/policy/list/localapp/
+- name: localized_policy
+  endpoint: /template/policy/vedge/
+- name: mesh_topology_policy_definition
+  endpoint: /template/policy/definition/mesh/
+- name: mirror_policy_object
+  endpoint: /template/policy/list/mirror/
+- name: object_group_policy_definition
+  endpoint: /template/policy/definition/securitygroup/
+- name: policer_policy_object
+  endpoint: /template/policy/list/policer/
+- name: policy_group
+  endpoint: /v1/policy-group/
+- name: port_list_policy_object
+  endpoint: /template/policy/list/port/
+- name: preferred_color_group_policy_object
+  endpoint: /template/policy/list/preferredcolorgroup/
+- name: protocol_list_policy_object
+  endpoint: /template/policy/list/protocolname/
+- name: qos_map_policy_definition
+  endpoint: /template/policy/definition/qosmap/
+- name: region_list_policy_object
+  endpoint: /template/policy/list/region/
+- name: rewrite_rule_policy_definition
+  endpoint: /template/policy/definition/rewriterule/
+- name: route_policy_definition
+  endpoint: /template/policy/definition/vedgeroute/
+- name: rule_set_policy_definition
+  endpoint: /template/policy/definition/ruleset/
+- name: security_policy
+  endpoint: /template/policy/security/
+- name: sig_security_feature_profile
+  endpoint: /v1/feature-profile/sdwan/sig-security
+- name: site_list_policy_object
+  endpoint: /template/policy/list/site/
+- name: sla_class_policy_object
+  endpoint: /template/policy/list/sla/
+- name: standard_community_list_policy_object
+  endpoint: /template/policy/list/community/
+- name: tag
+  endpoint: /v1/tags
+- name: tloc_list_policy_object
+  endpoint: /template/policy/list/tloc/
+- name: tls_ssl_profile_policy_definition
+  endpoint: /template/policy/definition/sslutdprofile/
+- name: topology_group
+  endpoint: /v1/topology-group/
+- name: traffic_data_policy_definition
+  endpoint: /template/policy/definition/data/
 - name: url_filtering_definition
   endpoint: /template/policy/definition/urlfiltering/
 - name: vedge_inventory
@@ -433,5 +453,3 @@
   endpoint: /template/policy/definition/zonebasedfw/
 - name: zone_list_policy_object
   endpoint: /template/policy/list/zone/
-- name: feature_templates
-  endpoint: /template/feature/object/%i

--- a/nac_collector/resources/endpoints/sdwan.yaml
+++ b/nac_collector/resources/endpoints/sdwan.yaml
@@ -31,157 +31,80 @@
 - name: policy_object_feature_profile
   endpoint: /v1/feature-profile/sdwan/policy-object
   children:
-  - &id001
-    name: policy_object_app_probe_class
+  - name: policy_object_app_probe_class
     endpoint: /app-probe
-  - &id002
-    name: policy_object_application_list
+  - name: policy_object_application_list
     endpoint: /app-list
-  - &id003
-    name: policy_object_as_path_list
+  - name: policy_object_as_path_list
     endpoint: /as-path
-  - &id004
-    name: policy_object_class_map
+  - name: policy_object_class_map
     endpoint: /class
-  - &id005
-    name: policy_object_color_list
+  - name: policy_object_color_list
     endpoint: /color
-  - &id006
-    name: policy_object_data_ipv4_prefix_list
+  - name: policy_object_data_ipv4_prefix_list
     endpoint: /data-prefix
-  - &id007
-    name: policy_object_data_ipv6_prefix_list
+  - name: policy_object_data_ipv6_prefix_list
     endpoint: /data-ipv6-prefix
-  - &id008
-    name: policy_object_expanded_community_list
+  - name: policy_object_expanded_community_list
     endpoint: /expanded-community
-  - &id009
-    name: policy_object_extended_community_list
+  - name: policy_object_extended_community_list
     endpoint: /ext-community
-  - &id010
-    name: policy_object_ipv4_prefix_list
+  - name: policy_object_ipv4_prefix_list
     endpoint: /prefix
-  - &id011
-    name: policy_object_ipv6_prefix_list
+  - name: policy_object_ipv6_prefix_list
     endpoint: /ipv6-prefix
-  - &id012
-    name: policy_object_mirror
+  - name: policy_object_mirror
     endpoint: /mirror
-  - &id013
-    name: policy_object_policer
+  - name: policy_object_policer
     endpoint: /policer
-  - &id014
-    name: policy_object_preferred_color_group
+  - name: policy_object_preferred_color_group
     endpoint: /preferred-color-group
-  - &id015
-    name: policy_object_security_data_ipv4_prefix_list
+  - name: policy_object_security_data_ipv4_prefix_list
     endpoint: /security-data-ip-prefix
-  - &id016
-    name: policy_object_security_fqdn_list
+  - name: policy_object_security_fqdn_list
     endpoint: /security-fqdn
-  - &id017
-    name: policy_object_security_geolocation_list
+  - name: policy_object_security_geolocation_list
     endpoint: /security-geolocation
-  - &id018
-    name: policy_object_security_identity_list
+  - name: policy_object_security_identity_list
     endpoint: /security-identity
-  - &id019
-    name: policy_object_security_ips_signature
+  - name: policy_object_security_ips_signature
     endpoint: /security-ipssignature
-  - &id020
-    name: policy_object_security_local_application_list
+  - name: policy_object_security_local_application_list
     endpoint: /security-localapp
-  - &id021
-    name: policy_object_security_local_domain_list
+  - name: policy_object_security_local_domain_list
     endpoint: /security-localdomain
-  - &id022
-    name: policy_object_security_port_list
+  - name: policy_object_security_port_list
     endpoint: /security-port
-  - &id023
-    name: policy_object_security_protocol_list
+  - name: policy_object_security_protocol_list
     endpoint: /security-protocolname
-  - &id024
-    name: policy_object_security_scalable_group_tag_list
+  - name: policy_object_security_scalable_group_tag_list
     endpoint: /security-scalablegrouptag
-  - &id025
-    name: policy_object_security_url_allow_list
+  - name: policy_object_security_url_allow_list
     endpoint: /security-urllist
-  - &id026
-    name: policy_object_security_url_block_list
+  - name: policy_object_security_url_block_list
     endpoint: /security-urllist
-  - &id027
-    name: policy_object_security_zone
+  - name: policy_object_security_zone
     endpoint: /security-zone
-  - &id028
-    name: policy_object_sla_class_list
+  - name: policy_object_sla_class_list
     endpoint: /sla-class
-  - &id029
-    name: policy_object_standard_community_list
+  - name: policy_object_standard_community_list
     endpoint: /standard-community
-  - &id030
-    name: policy_object_tloc_list
+  - name: policy_object_tloc_list
     endpoint: /tloc
-  - &id031
-    name: policy_object_unified_advanced_inspection_profile
+  - name: policy_object_unified_advanced_inspection_profile
     endpoint: /unified/advanced-inspection-profile
-  - &id032
-    name: policy_object_unified_advanced_malware_protection
+  - name: policy_object_unified_advanced_malware_protection
     endpoint: /unified/advanced-malware-protection
-  - &id033
-    name: policy_object_unified_intrusion_prevention
+  - name: policy_object_unified_intrusion_prevention
     endpoint: /unified/intrusion-prevention
-  - &id034
-    name: policy_object_unified_tls_ssl_decryption
+  - name: policy_object_unified_tls_ssl_decryption
     endpoint: /unified/ssl-decryption
-  - &id035
-    name: policy_object_unified_tls_ssl_profile
+  - name: policy_object_unified_tls_ssl_profile
     endpoint: /unified/ssl-decryption-profile
-  - &id036
-    name: policy_object_unified_url_filtering
+  - name: policy_object_unified_url_filtering
     endpoint: /unified/url-filtering
-  - &id037
-    name: policy_object_vpn_group
+  - name: policy_object_vpn_group
     endpoint: /vpn-group
-- name: policy_object_feature_profile_parcels
-  endpoint: /v1/feature-profile/sdwan/policy-object
-  children:
-  - *id001
-  - *id002
-  - *id003
-  - *id004
-  - *id005
-  - *id006
-  - *id007
-  - *id008
-  - *id009
-  - *id010
-  - *id011
-  - *id012
-  - *id013
-  - *id014
-  - *id015
-  - *id016
-  - *id017
-  - *id018
-  - *id019
-  - *id020
-  - *id021
-  - *id022
-  - *id023
-  - *id024
-  - *id025
-  - *id026
-  - *id027
-  - *id028
-  - *id029
-  - *id030
-  - *id031
-  - *id032
-  - *id033
-  - *id034
-  - *id035
-  - *id036
-  - *id037
 - name: service_feature_profile
   endpoint: /v1/feature-profile/sdwan/service
   children:


### PR DESCRIPTION
Add remove_endpoints override for the data-source-only parcels definition that duplicated policy_object_feature_profile's endpoint tree