### PR TITLE
Collect CleanAir/RRM FRA templates via summary + per-ID GET lookup

### DIFF
--- a/nac_collector/controller/catalystcenter.py
+++ b/nac_collector/controller/catalystcenter.py
@@ -213,9 +213,30 @@ class CiscoClientCATALYSTCENTER(CiscoClientController):
                         endpoint_dict[endpoint["name"]].append(elem)
 
         elif isinstance(data.get("response"), list):
-            endpoint_dict[endpoint["name"]].append(
-                {"data": data.get("response"), "endpoint": endpoint["endpoint"]}
-            )
+            response_list = data.get("response")
+            if (
+                endpoint_key
+                and endpoint_key in self.id_lookup
+                and response_list
+                and all(isinstance(i, dict) for i in response_list)
+            ):
+                for item in response_list:
+                    item_id = self.get_id_value(item)
+                    item_endpoint = (
+                        new_endpoint.replace("%v", item_id)
+                        if item_id
+                        else new_endpoint
+                    )
+                    endpoint_dict[endpoint["name"]].append(
+                        {
+                            "data": item,
+                            "endpoint": item_endpoint,
+                        }
+                    )
+            else:
+                endpoint_dict[endpoint["name"]].append(
+                    {"data": response_list, "endpoint": endpoint["endpoint"]}
+                )
         elif data and data.get("response"):
             response_items = data.get("response")
             if response_items:
@@ -262,6 +283,16 @@ class CiscoClientCATALYSTCENTER(CiscoClientController):
                     if isinstance(el, dict)
                 ]
         endpoint_key = endpoint.get("endpoint", "")
+        lookup_config = self.id_lookup.get(endpoint_key, {})
+        nested_key = lookup_config.get("source_nested_key")
+        if nested_key and isinstance(look_data, list):
+            look_data = [
+                instance
+                for group in look_data
+                if isinstance(group, dict)
+                for instance in group.get(nested_key, [])
+                if isinstance(instance, dict)
+            ]
         if endpoint_key in self.id_lookup:
             source_key = self.id_lookup[endpoint_key]["source_key"]
             id_list = [
@@ -280,6 +311,13 @@ class CiscoClientCATALYSTCENTER(CiscoClientController):
             data = self.fetch_data_pagination(lookup_endpoint)
             if isinstance(data, dict) and data.get("response"):
                 data = data["response"]
+            if (
+                lookup_config.get("unwrap_single_response")
+                and isinstance(data, list)
+                and len(data) == 1
+                and isinstance(data[0], dict)
+            ):
+                data = data[0]
             if isinstance(data, dict):
                 data[self.id_lookup[endpoint_key].get("target_key", "id")] = id_
             elif isinstance(data, list):

--- a/nac_collector/resources/lookups/catalystcenter.yaml
+++ b/nac_collector/resources/lookups/catalystcenter.yaml
@@ -73,4 +73,16 @@
   source_key: id
   target_endpoint: /dna/intent/api/v1/wirelessControllers/%v/secondaryManagedApLocations
   target_key: deviceId
+- endpoint: /dna/intent/api/v1/featureTemplates/wireless/cleanAirConfigurations
+  source_endpoint: /dna/intent/api/v1/featureTemplates/wireless/summary?type=CLEANAIR_CONFIGURATION&limit=25
+  source_nested_key: instances
+  source_key: id
+  target_endpoint: /dna/intent/api/v1/featureTemplates/wireless/cleanAirConfigurations/%v
+  unwrap_single_response: true
+- endpoint: /dna/intent/api/v1/featureTemplates/wireless/rrmFraConfigurations
+  source_endpoint: /dna/intent/api/v1/featureTemplates/wireless/summary?type=RRM_FRA_CONFIGURATION&limit=25
+  source_nested_key: instances
+  source_key: id
+  target_endpoint: /dna/intent/api/v1/featureTemplates/wireless/rrmFraConfigurations/%v
+  unwrap_single_response: true
 

--- a/tests/unit/test_catalystcenter_feature_templates.py
+++ b/tests/unit/test_catalystcenter_feature_templates.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nac_collector.controller.catalystcenter import CiscoClientCATALYSTCENTER
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def catalyst_client():
+    client = CiscoClientCATALYSTCENTER(
+        username="admin",
+        password="secret",
+        base_url="https://catc.example.com",
+        max_retries=1,
+        retry_after=0,
+        timeout=5,
+        ssl_verify=False,
+    )
+    client.db = MagicMock()
+    client.db.get.return_value = None
+    return client
+
+
+class TestFeatureTemplateAlternateFetch:
+    def test_fetch_data_alternate_flattens_summary_instances(self, catalyst_client):
+        endpoint = {
+            "name": "wireless_rrm_fra_configuration",
+            "endpoint": (
+                "/dna/intent/api/v1/featureTemplates/wireless/rrmFraConfigurations"
+            ),
+        }
+        summary = {
+            "response": [
+                {
+                    "type": "RRM_FRA_CONFIGURATION",
+                    "count": 2,
+                    "instances": [
+                        {"designName": "template-a", "id": "id-a"},
+                        {"designName": "template-b", "id": "id-b"},
+                    ],
+                }
+            ]
+        }
+        detail_a = {
+            "response": {
+                "id": "id-a",
+                "designName": "template-a",
+                "featureAttributes": {"fraStatus": True},
+            }
+        }
+        detail_b = {
+            "response": {
+                "id": "id-b",
+                "designName": "template-b",
+                "featureAttributes": {"fraStatus": False},
+            }
+        }
+
+        with patch.object(
+            catalyst_client, "fetch_data_pagination", side_effect=[summary, detail_a, detail_b]
+        ) as mock_fetch:
+            result = catalyst_client.fetch_data_alternate(endpoint)
+
+        assert mock_fetch.call_args_list[0].args[0].endswith(
+            "summary?type=RRM_FRA_CONFIGURATION&limit=25"
+        )
+        assert result == {
+            "response": [
+                {
+                    "id": "id-a",
+                    "designName": "template-a",
+                    "featureAttributes": {"fraStatus": True},
+                },
+                {
+                    "id": "id-b",
+                    "designName": "template-b",
+                    "featureAttributes": {"fraStatus": False},
+                },
+            ]
+        }
+
+    def test_process_endpoint_data_emits_per_template_entries(self, catalyst_client):
+        endpoint = {
+            "name": "wireless_cleanair_configuration",
+            "endpoint": (
+                "/dna/intent/api/v1/featureTemplates/wireless/cleanAirConfigurations"
+            ),
+        }
+        endpoint_dict = {"wireless_cleanair_configuration": []}
+        data = {
+            "response": [
+                {
+                    "id": "abc-123",
+                    "designName": "CLEANAIR_TEST",
+                    "featureAttributes": {"cleanAir": True},
+                }
+            ]
+        }
+
+        result = catalyst_client.process_endpoint_data(endpoint, endpoint_dict, data)
+
+        assert result["wireless_cleanair_configuration"] == [
+            {
+                "data": {
+                    "id": "abc-123",
+                    "designName": "CLEANAIR_TEST",
+                    "featureAttributes": {"cleanAir": True},
+                },
+                "endpoint": (
+                    "/dna/intent/api/v1/featureTemplates/wireless/"
+                    "cleanAirConfigurations/abc-123"
+                ),
+            }
+        ]


### PR DESCRIPTION
Add id_lookup entries for cleanAirConfigurations and rrmFraConfigurations
that source IDs from /featureTemplates/wireless/summary and fetch details
from the per-template GET endpoints. Extend fetch_data_alternate with
source_nested_key and unwrap_single_response, and emit one collector entry
per template for id_lookup list responses