### PR TITLE
fix(ndfc): authentication to use camelCase keys and domain

### DIFF
--- a/nac_collector/controller/ndfc.py
+++ b/nac_collector/controller/ndfc.py
@@ -784,17 +784,9 @@ class CiscoClientNDFC(CiscoClientController):
         try:
             logger.debug("Fetching all policies from endpoint: %s", endpoint_url)
 
-            # NOTE: this endpoint's URL carries a "/pagination" suffix and accepts
-            # "offset"/"limit" query params, but verified against a live NDFC 12.x
-            # (ND-hosted) instance it ignores both and always returns the complete,
-            # fabric-scoped policy set in a single response. Using
-            # fetch_data_pagination() here previously caused an infinite loop:
-            # since the response is never truncated below the assumed page size,
-            # the loop's only termination check (len(page) < limit) was never
-            # satisfied, so "offset" grew without bound and the same full result
-            # set was re-fetched and re-appended forever (see issue #272).
-            # A single fetch_data() call already retrieves 100% of the data.
-            all_policies_data = self.fetch_data(endpoint_url)
+            # The policies endpoint is paginated; use the parent class pagination
+            # helper so all pages are retrieved (fabrics can hold large policy sets).
+            all_policies_data = self.fetch_data_pagination(endpoint_url)
 
             if all_policies_data is not None:
                 logger.info("Successfully retrieved all policies data")

--- a/nac_collector/controller/ndfc.py
+++ b/nac_collector/controller/ndfc.py
@@ -784,9 +784,17 @@ class CiscoClientNDFC(CiscoClientController):
         try:
             logger.debug("Fetching all policies from endpoint: %s", endpoint_url)
 
-            # The policies endpoint is paginated; use the parent class pagination
-            # helper so all pages are retrieved (fabrics can hold large policy sets).
-            all_policies_data = self.fetch_data_pagination(endpoint_url)
+            # NOTE: this endpoint's URL carries a "/pagination" suffix and accepts
+            # "offset"/"limit" query params, but verified against a live NDFC 12.x
+            # (ND-hosted) instance it ignores both and always returns the complete,
+            # fabric-scoped policy set in a single response. Using
+            # fetch_data_pagination() here previously caused an infinite loop:
+            # since the response is never truncated below the assumed page size,
+            # the loop's only termination check (len(page) < limit) was never
+            # satisfied, so "offset" grew without bound and the same full result
+            # set was re-fetched and re-appended forever (see issue #272).
+            # A single fetch_data() call already retrieves 100% of the data.
+            all_policies_data = self.fetch_data(endpoint_url)
 
             if all_policies_data is not None:
                 logger.info("Successfully retrieved all policies data")

--- a/nac_collector/controller/ndfc.py
+++ b/nac_collector/controller/ndfc.py
@@ -119,9 +119,23 @@ class CiscoClientNDFC(CiscoClientController):
         # This is the ONLY hardcoded endpoint - authentication endpoint
         auth_endpoint = "/login"
         auth_url = f"{self.base_url}{auth_endpoint}"
-        auth_data = {"username": self.username, "password": self.password}
+        # NOTE: Nexus Dashboard's shared platform /login endpoint (also used by
+        # CiscoClientNDO) only honors the authentication domain when the
+        # credential keys are "userName"/"userPasswd" (camelCase). Sending
+        # lowercase "username"/"password" causes ND to silently ignore the
+        # "domain" field and fall back to local-domain auth semantics, which
+        # breaks authentication for any account that only exists in a
+        # non-local domain (LDAP/RADIUS/TACACS+/SAML realm, etc.).
+        auth_data = {
+            "userName": self.username,
+            "userPasswd": self.password,
+            "domain": self.domain,
+        }
+        # auth_data = {"username": self.username, "password": self.password}
 
-        logger.info("Authenticating with NDFC at %s", auth_url)
+        logger.info(
+            "Authenticating with NDFC at %s (domain: %s)", auth_url, self.domain
+        )
 
         try:
             response = self.client.post(auth_url, json=auth_data)

--- a/tests/unit/ndfc/test_authentication.py
+++ b/tests/unit/ndfc/test_authentication.py
@@ -38,6 +38,22 @@ def ndfc_client_no_creds():
     )
 
 
+@pytest.fixture
+def ndfc_client_custom_domain():
+    """NDFC client configured with a non-default authentication domain."""
+    return CiscoClientNDFC(
+        username="admin",
+        password="admin_pass",
+        base_url="https://ndfc.example.com",
+        max_retries=3,
+        retry_after=1,
+        timeout=5,
+        ssl_verify=False,
+        fabric_name="test-fabric",
+        domain="ISE",
+    )
+
+
 class TestAuthSuccess:
     """Tests for successful authentication scenarios."""
 
@@ -129,7 +145,72 @@ class TestAuthSuccess:
 
         mock_post.assert_called_once_with(
             "https://ndfc.example.com/login",
-            json={"username": "admin", "password": "admin_pass"},
+            json={
+                "userName": "admin",
+                "userPasswd": "admin_pass",
+                "domain": "local",
+            },
+        )
+
+    def test_authenticate_includes_default_domain_when_not_specified(self, ndfc_client):
+        """Domain should default to 'local' and always be sent in the login payload."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"token": "tok"}
+        mock_response.headers = {}
+
+        with patch.object(
+            httpx.Client, "post", return_value=mock_response
+        ) as mock_post:
+            ndfc_client.authenticate()
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["domain"] == "local"
+
+    def test_authenticate_uses_camelcase_credential_keys(self, ndfc_client):
+        """ND's shared /login endpoint only honors 'domain' when the credential
+        keys are userName/userPasswd (camelCase) -- lowercase username/password
+        keys cause ND to silently ignore 'domain' and fall back to local-domain
+        auth semantics. Verified against a live ND 4.2 instance."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"token": "tok"}
+        mock_response.headers = {}
+
+        with patch.object(
+            httpx.Client, "post", return_value=mock_response
+        ) as mock_post:
+            ndfc_client.authenticate()
+
+        _, kwargs = mock_post.call_args
+        sent_json = kwargs["json"]
+        assert "userName" in sent_json
+        assert "userPasswd" in sent_json
+        assert "username" not in sent_json
+        assert "password" not in sent_json
+
+    def test_authenticate_includes_custom_domain_in_login_payload(
+        self, ndfc_client_custom_domain
+    ):
+        """A non-default domain (e.g. a remote AAA realm) must be sent to /login."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"token": "tok"}
+        mock_response.headers = {}
+
+        with patch.object(
+            httpx.Client, "post", return_value=mock_response
+        ) as mock_post:
+            result = ndfc_client_custom_domain.authenticate()
+
+        assert result is True
+        mock_post.assert_called_once_with(
+            "https://ndfc.example.com/login",
+            json={
+                "userName": "admin",
+                "userPasswd": "admin_pass",
+                "domain": "ISE",
+            },
         )
 
 


### PR DESCRIPTION
Fix for https://github.com/netascode/nac-collector/issues/271