### PR TITLE
feat(ndfc): collect port channel interfaces

### DIFF
--- a/nac_collector/controller/ndfc.py
+++ b/nac_collector/controller/ndfc.py
@@ -26,11 +26,11 @@ class CiscoClientNDFC(CiscoClientController):
     # These interface types must have:
     # 1. A 'vpcEntityId' field with format "serial1~serial2~vpcX"
     # 2. Children endpoints defined in YAML configuration
-    # 3. The same processing pattern for child endpoints like vPCInterfaceSetting
-    PORT_CHANNEL_INTERFACE_TYPES = [
-        "TrunkPort-Channel",
-        "AccessPort-Channel",
-        # Add new Port-Channel interface types here as needed
+    # 3. The same processing pattern for child endpoints like VpcInterfaceSetting
+    VPC_PORT_CHANNEL_INTERFACE_TYPES = [
+        "VpcTrunkPortChannel",
+        "VpcAccessPortChannel"
+        # Add new vPC Port-Channel interface types here as needed
     ]
 
     # Interface types that use serial number + interface name processing logic
@@ -42,6 +42,8 @@ class CiscoClientNDFC(CiscoClientController):
         "LoopbackInterfaces",
         "AccessEthernetPorts",
         "TrunkEthernetPorts",
+        "TrunkPortChannel",
+        "AccessPortChannel"
         # Add new serial-based interface types here as needed
     ]
 
@@ -1191,6 +1193,9 @@ class CiscoClientNDFC(CiscoClientController):
             self._process_vrf_attachments(parent_endpoint, endpoint_dict)
         elif parent_name == "Discovered_Switches":
             self._process_switch_interfaces(parent_endpoint, endpoint_dict)
+        elif parent_name in self.VPC_PORT_CHANNEL_INTERFACE_TYPES:
+            # Handle vPC Port-Channel interfaces that use vpcEntityId pattern
+            self._process_port_channel_children(parent_endpoint, endpoint_dict)
         elif parent_name in self.VPC_PAIR_TYPES:
             self._process_vpc_pairs_children(parent_endpoint, endpoint_dict)
         else:
@@ -1695,9 +1700,95 @@ class CiscoClientNDFC(CiscoClientController):
                     else:
                         logger.debug("Skipping network with missing networkName")
 
-    def _process_vpc_pairs_children(
-        self, parent_endpoint: dict[str, Any], endpoint_dict: dict[str, Any]
-    ) -> None:
+    def _process_port_channel_children(self, parent_endpoint, endpoint_dict):
+        """
+        Process children endpoints for vPC Port-Channel interface types (VpcTrunkPortChannel, VpcAccessPortChannel, etc.).
+        Fetches child endpoint data (like VpcInterfaceSetting) for each vPC Port-Channel interface.
+        
+        This method handles all interface types that:
+        1. Have a 'vpcEntityId' field with format "serial1~serial2~vpcX"
+        2. Are defined in the VPC_PORT_CHANNEL_INTERFACE_TYPES class constant
+        
+        To add support for new vPC Port-Channel interface types:
+        1. Add the interface type name to VPC_PORT_CHANNEL_INTERFACE_TYPES constant
+        2. Define the interface endpoint and children in the YAML configuration
+        3. No code changes are required as this method handles them generically
+
+        Parameters:
+            parent_endpoint (dict): The parent Port-Channel endpoint.
+            endpoint_dict (dict): The dictionary containing the processed data.
+        """
+        parent_name = parent_endpoint["name"]
+        
+        # Get the children endpoint configurations
+        children_endpoints = parent_endpoint.get("children", [])
+        
+        if not children_endpoints:
+            logger.debug("No children endpoints defined for %s", parent_name)
+            return
+
+        logger.info("Processing %d children endpoints for %s", len(children_endpoints), parent_name)
+        
+        # Get Port-Channel data from the endpoint_dict
+        port_channels = endpoint_dict.get(parent_name, [])
+        
+        if not port_channels:
+            logger.warning("No %s data found to process children for", parent_name)
+            return
+
+        # Process each Port-Channel interface
+        processed_count = 0
+        for port_channel_data in port_channels:
+            # Extract vpcEntityId which contains the pattern "serial1~serial2~vpcX"
+            vpc_entity_id = port_channel_data.get("vpcEntityId")
+            
+            if not vpc_entity_id:
+                logger.debug("No vpcEntityId found in %s data, skipping", parent_name)
+                continue
+
+            # Parse the vpcEntityId to extract vpcPair and vPC_name
+            vpc_pair, vpc_name = self._parse_vpc_entity_id(vpc_entity_id)
+            
+            if not vpc_pair or not vpc_name:
+                logger.warning("Failed to parse vpcEntityId: %s", vpc_entity_id)
+                continue
+
+            logger.debug("Processing %s children for vpcPair=%s, vPC_name=%s", parent_name, vpc_pair, vpc_name)
+
+            # Process each child endpoint
+            for child_endpoint in children_endpoints:
+                child_name = child_endpoint["name"]
+                child_url = child_endpoint["endpoint"]
+
+                # Replace variables in the child endpoint URL
+                child_url = child_url.replace("{{vpcPair}}", vpc_pair)
+                child_url = child_url.replace("{{vPC_name}}", vpc_name)
+
+                # Replace fabric ID if present
+                if self.fabric_id and "{{fabricID}}" in child_url:
+                    child_url = child_url.replace("{{fabricID}}", str(self.fabric_id))
+
+                logger.debug("Fetching child endpoint: %s -> %s", child_name, child_url)
+
+                try:
+                    response = self.client.get(f"{self.base_url}{child_url}")
+                    response.raise_for_status()
+                    child_data = response.json()
+
+                    # Save child data directly to the Port-Channel entry using the child endpoint name as key
+                    port_channel_data[child_name] = child_data
+
+                    processed_count += 1
+                    logger.debug("Successfully processed and saved child endpoint %s to %s entry for %s", child_name, parent_name, vpc_name)
+
+                except Exception as e:
+                    logger.error("Error processing child endpoint %s for %s: %s", child_name, vpc_name, str(e))
+                    # Set empty data on error to maintain consistent structure
+                    port_channel_data[child_name] = {}
+
+        logger.info("Completed processing %s children. Processed %d items", parent_name, processed_count)
+
+    def _process_vpc_pairs_children(self, parent_endpoint, endpoint_dict):
         """
         Process children endpoints for VPC pair types (VPC_Pairs).
         Fetches child endpoint data (like VPC_PeerLinkSettings) for each VPC pair.
@@ -1817,8 +1908,8 @@ class CiscoClientNDFC(CiscoClientController):
         self, parent_endpoint: dict[str, Any], interface_data: Any, sys_name: str
     ) -> None:
         """
-        Process nested children endpoints for interface data (like Port-Channel interfaces -> vPCInterfaceSetting).
-
+        Process nested children endpoints for interface data (like vPC Port-Channel interfaces -> VpcInterfaceSetting).
+        
         Parameters:
             parent_endpoint (dict): The parent endpoint configuration with children
             interface_data (list): The interface data from the parent endpoint
@@ -1847,9 +1938,9 @@ class CiscoClientNDFC(CiscoClientController):
         ):
             if not isinstance(interface_entry, dict):
                 continue
-
-            # For Port-Channel interfaces (TrunkPort-Channel, AccessPort-Channel, etc.), look for vpcEntityId
-            if parent_name in self.PORT_CHANNEL_INTERFACE_TYPES:
+                
+            # For vPC Port-Channel interfaces (VpcTrunkPortChannel, VpcAccessPortChannel, etc.), look for vpcEntityId
+            if parent_name in self.VPC_PORT_CHANNEL_INTERFACE_TYPES:
                 vpc_entity_id = interface_entry.get("vpcEntityId")
 
                 if not vpc_entity_id:

--- a/nac_collector/controller/ndfc.py
+++ b/nac_collector/controller/ndfc.py
@@ -1304,11 +1304,11 @@ class CiscoClientNDFC(CiscoClientController):
                 if (
                     not switch
                     or not isinstance(switch, dict)
-                    or not switch.get("hostName")
+                    or not switch.get("logicalName")
                 ):
                     continue
 
-                host_name = switch.get("hostName")
+                sys_name = switch.get("logicalName")
                 serial_number = switch.get("serialNumber")
                 switch_fabric_name = switch.get("fabricName")
 
@@ -1318,7 +1318,7 @@ class CiscoClientNDFC(CiscoClientController):
                 current_fabric = config_entry.get("fabric")
                 logger.debug(
                     "Switch fabric check: switch %s belongs to fabric %s, currently processing fabric %s",
-                    host_name,
+                    sys_name,
                     switch_fabric_name,
                     current_fabric,
                 )
@@ -1329,7 +1329,7 @@ class CiscoClientNDFC(CiscoClientController):
                 ):
                     logger.debug(
                         "Skipping switch %s (belongs to fabric %s, currently processing fabric %s)",
-                        host_name,
+                        sys_name,
                         switch_fabric_name,
                         current_fabric,
                     )
@@ -1337,7 +1337,7 @@ class CiscoClientNDFC(CiscoClientController):
 
                 logger.debug(
                     "Processing interfaces for switch: %s (serial: %s)",
-                    host_name,
+                    sys_name,
                     serial_number,
                 )
 
@@ -1353,7 +1353,7 @@ class CiscoClientNDFC(CiscoClientController):
                     logger.debug(
                         "Processing child endpoint %s for switch %s",
                         child_name,
-                        host_name,
+                        sys_name,
                     )
 
                     # Get the switch's actual fabric information
@@ -1371,12 +1371,12 @@ class CiscoClientNDFC(CiscoClientController):
                         logger.debug(
                             "Using switch's fabric ID %s for %s in fabric %s",
                             switch_fabric_id,
-                            host_name,
+                            sys_name,
                             switch_fabric_name,
                         )
 
-                    if host_name and "{{hostName}}" in child_url:
-                        child_url = child_url.replace("{{hostName}}", host_name)
+                    if sys_name and "{{sysName}}" in child_url:
+                        child_url = child_url.replace("{{sysName}}", sys_name)
 
                     if serial_number and "{{serialNumber}}" in child_url:
                         child_url = child_url.replace("{{serialNumber}}", serial_number)
@@ -1393,7 +1393,7 @@ class CiscoClientNDFC(CiscoClientController):
                             logger.debug(
                                 "Successfully retrieved %s for switch: %s",
                                 child_name,
-                                host_name,
+                                sys_name,
                             )
 
                             # Process the interface data (normalize structure)
@@ -1412,10 +1412,10 @@ class CiscoClientNDFC(CiscoClientController):
                                     logger.debug(
                                         "Processing nested children for %s on switch %s",
                                         child_name,
-                                        host_name,
+                                        sys_name,
                                     )
                                     self._process_nested_children_for_interfaces(
-                                        child_endpoint, processed_interfaces, host_name
+                                        child_endpoint, processed_interfaces, sys_name
                                     )
 
                             logger.debug("Processed child name: %s", child_name)
@@ -1426,13 +1426,13 @@ class CiscoClientNDFC(CiscoClientController):
                                 if isinstance(processed_interfaces, list)
                                 else 1,
                                 child_name,
-                                host_name,
+                                sys_name,
                             )
                         else:
                             logger.warning(
                                 "Failed to fetch %s for switch: %s",
                                 child_name,
-                                host_name,
+                                sys_name,
                             )
                             switch["interfaces"][child_name] = []
 
@@ -1440,7 +1440,7 @@ class CiscoClientNDFC(CiscoClientController):
                         logger.error(
                             "Error fetching %s for switch %s: %s",
                             child_name,
-                            host_name,
+                            sys_name,
                             str(e),
                         )
                         switch["interfaces"][child_name] = []
@@ -1814,7 +1814,7 @@ class CiscoClientNDFC(CiscoClientController):
         )
 
     def _process_nested_children_for_interfaces(
-        self, parent_endpoint: dict[str, Any], interface_data: Any, host_name: str
+        self, parent_endpoint: dict[str, Any], interface_data: Any, sys_name: str
     ) -> None:
         """
         Process nested children endpoints for interface data (like Port-Channel interfaces -> vPCInterfaceSetting).
@@ -1822,7 +1822,7 @@ class CiscoClientNDFC(CiscoClientController):
         Parameters:
             parent_endpoint (dict): The parent endpoint configuration with children
             interface_data (list): The interface data from the parent endpoint
-            host_name (str): The hostname of the switch being processed
+            sys_name (str): The sysName (logicalName) of the switch being processed
         """
         parent_name = parent_endpoint["name"]
         children_endpoints = parent_endpoint.get("children", [])
@@ -1834,7 +1834,7 @@ class CiscoClientNDFC(CiscoClientController):
             "Processing %d nested children for %s interfaces on switch %s",
             len(children_endpoints),
             parent_name,
-            host_name,
+            sys_name,
         )
 
         if self.client is None:
@@ -1870,7 +1870,7 @@ class CiscoClientNDFC(CiscoClientController):
                     "Processing nested children for vpcPair=%s, vPC_name=%s on switch %s",
                     vpc_pair,
                     vpc_name,
-                    host_name,
+                    sys_name,
                 )
 
                 # Process each nested child endpoint
@@ -1904,7 +1904,7 @@ class CiscoClientNDFC(CiscoClientController):
                             "Successfully processed and saved nested child endpoint %s to interface entry for %s on switch %s",
                             child_name,
                             vpc_name,
-                            host_name,
+                            sys_name,
                         )
 
                     except Exception as e:
@@ -1912,7 +1912,7 @@ class CiscoClientNDFC(CiscoClientController):
                             "Error processing nested child endpoint %s for %s on switch %s: %s",
                             child_name,
                             vpc_name,
-                            host_name,
+                            sys_name,
                             str(e),
                         )
                         # Set empty data on error to maintain consistent structure
@@ -1934,7 +1934,7 @@ class CiscoClientNDFC(CiscoClientController):
                     "Processing nested children for serialNumber=%s, ifName=%s on switch %s",
                     serial_number,
                     if_name,
-                    host_name,
+                    sys_name,
                 )
 
                 # Process each nested child endpoint
@@ -1968,7 +1968,7 @@ class CiscoClientNDFC(CiscoClientController):
                             "Successfully processed and saved nested child endpoint %s to interface entry for %s on switch %s",
                             child_name,
                             if_name,
-                            host_name,
+                            sys_name,
                         )
 
                     except Exception as e:
@@ -1976,7 +1976,7 @@ class CiscoClientNDFC(CiscoClientController):
                             "Error processing nested child endpoint %s for %s on switch %s: %s",
                             child_name,
                             if_name,
-                            host_name,
+                            sys_name,
                             str(e),
                         )
                         # Set empty data on error to maintain consistent structure

--- a/nac_collector/controller/ndfc.py
+++ b/nac_collector/controller/ndfc.py
@@ -1697,7 +1697,9 @@ class CiscoClientNDFC(CiscoClientController):
                     else:
                         logger.debug("Skipping network with missing networkName")
 
-    def _process_vpc_pairs_children(self, parent_endpoint, endpoint_dict):
+    def _process_vpc_pairs_children(
+        self, parent_endpoint: dict[str, Any], endpoint_dict: dict[str, Any]
+    ) -> None:
         """
         Process children endpoints for VPC pair types (VPC_Pairs).
         Fetches child endpoint data (like VPC_PeerLinkSettings) for each VPC pair.

--- a/nac_collector/controller/ndfc.py
+++ b/nac_collector/controller/ndfc.py
@@ -26,10 +26,10 @@ class CiscoClientNDFC(CiscoClientController):
     # These interface types must have:
     # 1. A 'vpcEntityId' field with format "serial1~serial2~vpcX"
     # 2. Children endpoints defined in YAML configuration
-    # 3. The same processing pattern for child endpoints like VpcInterfaceSetting
+    # 3. The same processing pattern for child endpoints like vPCInterfaceSetting
     VPC_PORT_CHANNEL_INTERFACE_TYPES = [
-        "VpcTrunkPortChannel",
-        "VpcAccessPortChannel"
+        "vPCTrunkPortChannel",
+        "vPCAccessPortChannel"
         # Add new vPC Port-Channel interface types here as needed
     ]
 
@@ -1702,8 +1702,8 @@ class CiscoClientNDFC(CiscoClientController):
 
     def _process_port_channel_children(self, parent_endpoint, endpoint_dict):
         """
-        Process children endpoints for vPC Port-Channel interface types (VpcTrunkPortChannel, VpcAccessPortChannel, etc.).
-        Fetches child endpoint data (like VpcInterfaceSetting) for each vPC Port-Channel interface.
+        Process children endpoints for vPC Port-Channel interface types (vPCTrunkPortChannel, vPCAccessPortChannel, etc.).
+        Fetches child endpoint data (like vPCInterfaceSetting) for each vPC Port-Channel interface.
         
         This method handles all interface types that:
         1. Have a 'vpcEntityId' field with format "serial1~serial2~vpcX"
@@ -1908,7 +1908,7 @@ class CiscoClientNDFC(CiscoClientController):
         self, parent_endpoint: dict[str, Any], interface_data: Any, sys_name: str
     ) -> None:
         """
-        Process nested children endpoints for interface data (like vPC Port-Channel interfaces -> VpcInterfaceSetting).
+        Process nested children endpoints for interface data (like vPC Port-Channel interfaces -> vPCInterfaceSetting).
         
         Parameters:
             parent_endpoint (dict): The parent endpoint configuration with children
@@ -1939,7 +1939,7 @@ class CiscoClientNDFC(CiscoClientController):
             if not isinstance(interface_entry, dict):
                 continue
                 
-            # For vPC Port-Channel interfaces (VpcTrunkPortChannel, VpcAccessPortChannel, etc.), look for vpcEntityId
+            # For vPC Port-Channel interfaces (vPCTrunkPortChannel, vPCAccessPortChannel, etc.), look for vpcEntityId
             if parent_name in self.VPC_PORT_CHANNEL_INTERFACE_TYPES:
                 vpc_entity_id = interface_entry.get("vpcEntityId")
 

--- a/nac_collector/controller/ndfc.py
+++ b/nac_collector/controller/ndfc.py
@@ -1193,9 +1193,6 @@ class CiscoClientNDFC(CiscoClientController):
             self._process_vrf_attachments(parent_endpoint, endpoint_dict)
         elif parent_name == "Discovered_Switches":
             self._process_switch_interfaces(parent_endpoint, endpoint_dict)
-        elif parent_name in self.VPC_PORT_CHANNEL_INTERFACE_TYPES:
-            # Handle vPC Port-Channel interfaces that use vpcEntityId pattern
-            self._process_port_channel_children(parent_endpoint, endpoint_dict)
         elif parent_name in self.VPC_PAIR_TYPES:
             self._process_vpc_pairs_children(parent_endpoint, endpoint_dict)
         else:
@@ -1699,94 +1696,6 @@ class CiscoClientNDFC(CiscoClientController):
                         )
                     else:
                         logger.debug("Skipping network with missing networkName")
-
-    def _process_port_channel_children(self, parent_endpoint, endpoint_dict):
-        """
-        Process children endpoints for vPC Port-Channel interface types (vPCTrunkPortChannel, vPCAccessPortChannel, etc.).
-        Fetches child endpoint data (like vPCInterfaceSetting) for each vPC Port-Channel interface.
-        
-        This method handles all interface types that:
-        1. Have a 'vpcEntityId' field with format "serial1~serial2~vpcX"
-        2. Are defined in the VPC_PORT_CHANNEL_INTERFACE_TYPES class constant
-        
-        To add support for new vPC Port-Channel interface types:
-        1. Add the interface type name to VPC_PORT_CHANNEL_INTERFACE_TYPES constant
-        2. Define the interface endpoint and children in the YAML configuration
-        3. No code changes are required as this method handles them generically
-
-        Parameters:
-            parent_endpoint (dict): The parent Port-Channel endpoint.
-            endpoint_dict (dict): The dictionary containing the processed data.
-        """
-        parent_name = parent_endpoint["name"]
-        
-        # Get the children endpoint configurations
-        children_endpoints = parent_endpoint.get("children", [])
-        
-        if not children_endpoints:
-            logger.debug("No children endpoints defined for %s", parent_name)
-            return
-
-        logger.info("Processing %d children endpoints for %s", len(children_endpoints), parent_name)
-        
-        # Get Port-Channel data from the endpoint_dict
-        port_channels = endpoint_dict.get(parent_name, [])
-        
-        if not port_channels:
-            logger.warning("No %s data found to process children for", parent_name)
-            return
-
-        # Process each Port-Channel interface
-        processed_count = 0
-        for port_channel_data in port_channels:
-            # Extract vpcEntityId which contains the pattern "serial1~serial2~vpcX"
-            vpc_entity_id = port_channel_data.get("vpcEntityId")
-            
-            if not vpc_entity_id:
-                logger.debug("No vpcEntityId found in %s data, skipping", parent_name)
-                continue
-
-            # Parse the vpcEntityId to extract vpcPair and vPC_name
-            vpc_pair, vpc_name = self._parse_vpc_entity_id(vpc_entity_id)
-            
-            if not vpc_pair or not vpc_name:
-                logger.warning("Failed to parse vpcEntityId: %s", vpc_entity_id)
-                continue
-
-            logger.debug("Processing %s children for vpcPair=%s, vPC_name=%s", parent_name, vpc_pair, vpc_name)
-
-            # Process each child endpoint
-            for child_endpoint in children_endpoints:
-                child_name = child_endpoint["name"]
-                child_url = child_endpoint["endpoint"]
-
-                # Replace variables in the child endpoint URL
-                child_url = child_url.replace("{{vpcPair}}", vpc_pair)
-                child_url = child_url.replace("{{vPC_name}}", vpc_name)
-
-                # Replace fabric ID if present
-                if self.fabric_id and "{{fabricID}}" in child_url:
-                    child_url = child_url.replace("{{fabricID}}", str(self.fabric_id))
-
-                logger.debug("Fetching child endpoint: %s -> %s", child_name, child_url)
-
-                try:
-                    response = self.client.get(f"{self.base_url}{child_url}")
-                    response.raise_for_status()
-                    child_data = response.json()
-
-                    # Save child data directly to the Port-Channel entry using the child endpoint name as key
-                    port_channel_data[child_name] = child_data
-
-                    processed_count += 1
-                    logger.debug("Successfully processed and saved child endpoint %s to %s entry for %s", child_name, parent_name, vpc_name)
-
-                except Exception as e:
-                    logger.error("Error processing child endpoint %s for %s: %s", child_name, vpc_name, str(e))
-                    # Set empty data on error to maintain consistent structure
-                    port_channel_data[child_name] = {}
-
-        logger.info("Completed processing %s children. Processed %d items", parent_name, processed_count)
 
     def _process_vpc_pairs_children(self, parent_endpoint, endpoint_dict):
         """

--- a/nac_collector/resources/endpoints/ndfc.yaml
+++ b/nac_collector/resources/endpoints/ndfc.yaml
@@ -15,21 +15,31 @@
     children:
     - name: TrunkInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{serialNumber}}&interfaceName={{ifName}}&policyName=int_trunk_host
-  - name: TrunkPort-Channel
+  - name: VpcTrunkPortChannel
     endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=vpcId%21%3D0%26%26sysName%3D%3D{{sysName}}%26%26underlayPolicies%3D%3Dint_vpc_trunk_po_11_1&navId={{fabricID}}
     children:
-    - name: vPCInterfaceSetting
+    - name: VpcInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{vpcPair}}&interfaceName={{vPC_name}}&policyName=int_vpc_trunk_host
-  - name: AccessPort-Channel
+  - name: VpcAccessPortChannel
     endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=vpcId%21%3D0%26%26sysName%3D%3D{{sysName}}%26%26underlayPolicies%3D%3Dint_vpc_access_po_11_1&navId={{fabricID}}
     children:
-    - name: vPCInterfaceSetting
+    - name: VpcInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{vpcPair}}&interfaceName={{vPC_name}}&policyName=int_vpc_access_host
   - name: LoopbackInterfaces
     endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=underlayPolicies%3D%3Dint_loopback%26%26sysName%3D%3D{{sysName}}&navId={{fabricID}}
     children:
     - name: LoopbackInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{serialNumber}}&interfaceName={{ifName}}&policyName=int_loopback
+  - name: TrunkPortChannel
+    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=underlayPolicies%3D%3Dint_port_channel_trunk_host%26%26sysName%3D%3D{{sysName}}&navId={{fabricID}}
+    children:
+    - name: TrunkPortChannelSetting
+      endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{serialNumber}}&interfaceName={{ifName}}&policyName=int_port_channel_trunk_host
+  - name: AccessPortChannel
+    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=underlayPolicies%3D%3Dint_port_channel_access_host%26%26sysName%3D%3D{{sysName}}&navId={{fabricID}}
+    children:
+    - name: AccessPortChannelSetting
+      endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{serialNumber}}&interfaceName={{ifName}}&policyName=int_port_channel_access_host
 - name: VPC_Pairs
   endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/vpcpair?navId={{fabricID}}
   children:

--- a/nac_collector/resources/endpoints/ndfc.yaml
+++ b/nac_collector/resources/endpoints/ndfc.yaml
@@ -6,27 +6,27 @@
   endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/%v/inventory
   children:
   - name: AccessEthernetPorts
-    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=underlayPolicies%3D%3Dint_access_host%26%26mode%3D%3Daccess%26%26sysName%3D%3D{{hostName}}&navId={{fabricID}}
+    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=underlayPolicies%3D%3Dint_access_host%26%26mode%3D%3Daccess%26%26sysName%3D%3D{{sysName}}&navId={{fabricID}}
     children:
     - name: AccessInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{serialNumber}}&interfaceName={{ifName}}&policyName=int_access_host
   - name: TrunkEthernetPorts
-    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=mode%3D%3Dtrunk%26%26sysName%3D%3D{{hostName}}%26%26underlayPolicies%3D%3Dint_trunk_host%26%26allowedVLANs%21%3Dnone&navId={{fabricID}}
+    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=mode%3D%3Dtrunk%26%26sysName%3D%3D{{sysName}}%26%26underlayPolicies%3D%3Dint_trunk_host%26%26allowedVLANs%21%3Dnone&navId={{fabricID}}
     children:
     - name: TrunkInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{serialNumber}}&interfaceName={{ifName}}&policyName=int_trunk_host
   - name: TrunkPort-Channel
-    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=vpcId%21%3D0%26%26sysName%3D%3D{{hostName}}%26%26underlayPolicies%3D%3Dint_vpc_trunk_po_11_1&navId={{fabricID}}
+    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=vpcId%21%3D0%26%26sysName%3D%3D{{sysName}}%26%26underlayPolicies%3D%3Dint_vpc_trunk_po_11_1&navId={{fabricID}}
     children:
     - name: vPCInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{vpcPair}}&interfaceName={{vPC_name}}&policyName=int_vpc_trunk_host
   - name: AccessPort-Channel
-    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=vpcId%21%3D0%26%26sysName%3D%3D{{hostName}}%26%26underlayPolicies%3D%3Dint_vpc_access_po_11_1&navId={{fabricID}}
+    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=vpcId%21%3D0%26%26sysName%3D%3D{{sysName}}%26%26underlayPolicies%3D%3Dint_vpc_access_po_11_1&navId={{fabricID}}
     children:
     - name: vPCInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{vpcPair}}&interfaceName={{vPC_name}}&policyName=int_vpc_access_host
   - name: LoopbackInterfaces
-    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=underlayPolicies%3D%3Dint_loopback%26%26sysName%3D%3D{{hostName}}&navId={{fabricID}}
+    endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=underlayPolicies%3D%3Dint_loopback%26%26sysName%3D%3D{{sysName}}&navId={{fabricID}}
     children:
     - name: LoopbackInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{serialNumber}}&interfaceName={{ifName}}&policyName=int_loopback

--- a/nac_collector/resources/endpoints/ndfc.yaml
+++ b/nac_collector/resources/endpoints/ndfc.yaml
@@ -15,15 +15,15 @@
     children:
     - name: TrunkInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{serialNumber}}&interfaceName={{ifName}}&policyName=int_trunk_host
-  - name: VpcTrunkPortChannel
+  - name: vPCTrunkPortChannel
     endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=vpcId%21%3D0%26%26sysName%3D%3D{{sysName}}%26%26underlayPolicies%3D%3Dint_vpc_trunk_po_11_1&navId={{fabricID}}
     children:
-    - name: VpcInterfaceSetting
+    - name: vPCInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{vpcPair}}&interfaceName={{vPC_name}}&policyName=int_vpc_trunk_host
-  - name: VpcAccessPortChannel
+  - name: vPCAccessPortChannel
     endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=vpcId%21%3D0%26%26sysName%3D%3D{{sysName}}%26%26underlayPolicies%3D%3Dint_vpc_access_po_11_1&navId={{fabricID}}
     children:
-    - name: VpcInterfaceSetting
+    - name: vPCInterfaceSetting
       endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface/pti/nvpairs?serialNumber={{vpcPair}}&interfaceName={{vPC_name}}&policyName=int_vpc_access_host
   - name: LoopbackInterfaces
     endpoint: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/globalInterface?filter=underlayPolicies%3D%3Dint_loopback%26%26sysName%3D%3D{{sysName}}&navId={{fabricID}}

--- a/tests/unit/ndfc/test_endpoint_wiring.py
+++ b/tests/unit/ndfc/test_endpoint_wiring.py
@@ -1,0 +1,53 @@
+import pytest
+
+from nac_collector.controller.ndfc import CiscoClientNDFC
+from nac_collector.resource_manager import ResourceManager
+
+pytestmark = pytest.mark.unit
+
+
+def _endpoint_by_interface_type() -> dict[str, dict]:
+    """Map each interface type (child of Discovered_Switches) to its yaml entry."""
+    endpoints = ResourceManager.get_packaged_endpoint_data("ndfc")
+    assert endpoints, "ndfc.yaml failed to load"
+
+    discovered = next(
+        (e for e in endpoints if e.get("name") == "Discovered_Switches"), None
+    )
+    assert discovered is not None, "Discovered_Switches key missing from ndfc.yaml"
+
+    return {child["name"]: child for child in discovered.get("children", [])}
+
+
+ENDPOINT_BY_INTERFACE_TYPE = _endpoint_by_interface_type()
+
+
+def _child_urls_for_interface_type(interface_type: str) -> list[str]:
+    entry = ENDPOINT_BY_INTERFACE_TYPE.get(interface_type)
+    assert entry is not None, f"{interface_type} not wired into Discovered_Switches"
+    child_urls = [c["endpoint"] for c in entry.get("children", [])]
+    assert child_urls, f"{interface_type} has no child endpoints"
+    return child_urls
+
+
+@pytest.mark.parametrize(
+    "interface_type", CiscoClientNDFC.VPC_PORT_CHANNEL_INTERFACE_TYPES
+)
+def test_vpc_interfaces_use_vpc_placeholders_in_children_endpoint_urls(interface_type):
+    urls = _child_urls_for_interface_type(interface_type)
+    assert all("{{vpcPair}}" in url and "{{vPC_name}}" in url for url in urls)
+
+
+@pytest.mark.parametrize("interface_type", CiscoClientNDFC.SERIAL_INTERFACE_TYPES)
+def test_serial_interfaces_use_serial_placeholders_in_children_endpoint_urls(
+    interface_type,
+):
+    urls = _child_urls_for_interface_type(interface_type)
+    assert all("{{serialNumber}}" in url and "{{ifName}}" in url for url in urls)
+
+
+def test_vpc_interfaces_and_serial_interfaces_do_not_overlap():
+    overlap = set(CiscoClientNDFC.SERIAL_INTERFACE_TYPES) & set(
+        CiscoClientNDFC.VPC_PORT_CHANNEL_INTERFACE_TYPES
+    )
+    assert not overlap, f"Interface types must be disjoint, but both contain: {overlap}"


### PR DESCRIPTION
## Dependency

Stacked on #275 .
Until that merges, this PR's diff will also show the commit above.

## Summary

BREAKING for downstream consumers of nac-collector's output

Adds collection of regular (per-switch) port-channel interfaces to the NDFC collector, and renames the pre-existing port-channel identifiers to make explicit that they were only handling VPC port-channels.

Two distinct kinds of port-channel now coexist:

| Kind | Discriminator | Policy filter | Child fetch key |
|------|---------------|---------------|-----------------|
| **vPC** port-channel (already collected, now renamed) | `vpcEntityId` = `serial1~serial2~vpcX` | `int_vpc_trunk_po_11_1` / `int_vpc_access_po_11_1` | `{{vpcPair}}` + `{{vPC_name}}` |
| **Regular** port-channel (new) | per-switch `serialNumber` + `ifName` | `int_port_channel_trunk_host` / `int_port_channel_access_host` | `{{serialNumber}}` + `{{ifName}}` |

### Why the renames

The original code named the VPC-only endpoints generically (`TrunkPort-Channel`, `AccessPort-Channel`, `vPCInterfaceSetting`, `PORT_CHANNEL_INTERFACE_TYPES`). 

To add *regular* member port-channels without an ambiguous collision, the existing vPC-specific names are prefixed with `vPC`, and the plain `TrunkPortChannel` / `AccessPortChannel` / `*Setting` names are used for the new serial-based endpoints.

### Renamed (vPC-specific)

| Before | After |
|--------|-------|
| `PORT_CHANNEL_INTERFACE_TYPES` | `VPC_PORT_CHANNEL_INTERFACE_TYPES` |
| `TrunkPort-Channel` | `vPCTrunkPortChannel` |
| `AccessPort-Channel` | `VpcAccessPortChannel` |
| `vPCInterfaceSetting` | `vPCInterfaceSetting` |

### Added 

- Endpoints `TrunkPortChannel` / `AccessPortChannel` (filtered on `int_port_channel_trunk_host` / `int_port_channel_access_host`), each with a `TrunkPortChannelSetting` / `AccessPortChannelSetting` child that fetches by `serialNumber` + `ifName`.
- Both new types registered in `SERIAL_BASED_INTERFACE_TYPES`