### PR TITLE
fix(cli): NDO client rebuilt without `domain` due to missing `elif`

### DIFF
--- a/nac_collector/cli/main.py
+++ b/nac_collector/cli/main.py
@@ -342,7 +342,7 @@ def main(
                     timeout=timeout,
                     ssl_verify=False,
                 )
-            if solution == Solution.CDFMC:
+            elif solution == Solution.CDFMC:
                 # For CDFMC, use FMC client but set cdfmc=True to adjust behavior
                 # Username is not used for CDFMC authentication
                 client = CiscoClientFMC(


### PR DESCRIPTION
## Summary

Running `nac-collector -s NDO --username ... --password ... --domain Local --url ...` fails with:

```
TypeError: CiscoClientNDO.__init__() missing 1 required positional argument: 'domain'
```

## Root cause

In `nac_collector/cli/main.py`, the client-construction chain looked like:

```python
if solution == Solution.NDO:
    client = CiscoClientNDO(..., domain=effective_domain, ...)  # good
if solution == Solution.CDFMC:                                  # bare `if`, should be `elif`
    ...
elif solution == Solution.SDWAN:
    ...
elif solution == Solution.NDFC:
    ...
else:
    client = cisco_client_class(username=..., password=..., base_url=..., ...)  # no `domain`
```

Because the second `if` started a fresh if/elif chain instead of continuing the first one, when `solution == NDO` the flow was:

1. NDO branch runs — `client` built correctly with `domain`.
2. `if CDFMC` is false — control enters the new chain and falls through CDFMC/SDWAN/NDFC to the trailing `else`.
3. The `else` invokes `cisco_client_class(...)` (still `CiscoClientNDO`) *without* the `domain` kwarg, raising the `TypeError`.

Introduced in #161.

## Fix

Change the offending `if` to `elif` so all branches form a single if/elif/…/else chain and only one client is constructed.

## Test plan

- [ ] `nac-collector -s NDO --username ... --password ... --domain Local --url https://<ndo>/` runs past client construction and reaches the authenticate step
- [ ] Other solutions (SDWAN, ISE, FMC, CDFMC, CATALYSTCENTER, MERAKI, NDFC) still construct their clients correctly
