### PR TITLE
fix(ise): add profilerprofile endpoint to ISE collection

### DIFF
--- a/nac_collector/resources/endpoint_overrides/ise.yaml
+++ b/nac_collector/resources/endpoint_overrides/ise.yaml
@@ -4,6 +4,10 @@
 # To apply modifications in this file,
 # regenerate the endpoints YAML with "uv run ./scripts/update_endpoints.py".
 
+extra_endpoints:
+- name: profiler_profile
+  endpoint: /ers/config/profilerprofile
+
 overrides:
 - name: network_access_dictionary
   id_field: name

--- a/nac_collector/resources/endpoints/ise.yaml
+++ b/nac_collector/resources/endpoints/ise.yaml
@@ -108,6 +108,8 @@
   endpoint: /ers/config/networkdevice
 - name: network_device_group
   endpoint: /ers/config/networkdevicegroup
+- name: profiler_profile
+  endpoint: /ers/config/profilerprofile
 - name: repository
   endpoint: /api/v1/repository
 - name: sxp_domain_filter


### PR DESCRIPTION
## Summary

Fixes #288

**Root cause:** \`profilerprofile\` is marked \`no_resource: true\` in the provider, so \`update_endpoints.py\` skips it by design — there is no managed Terraform resource for profiler profiles (they are read-only system objects built into ISE). As a result, \`/ers/config/profilerprofile\` was never called and the profiler profile list was absent from the collector output JSON.

**Impact:** Downstream tooling that resolves profiler profile UUIDs to human-readable names had no source data. Endpoint records with a static profile assignment would silently lose the profile name resolution.

**Fix:** Add \`profiler_profile\` to \`endpoint_overrides/ise.yaml\` under \`extra_endpoints\`. This is the correct mechanism for endpoints that should be collected even though the provider marks them \`no_resource: true\` — the generator skips them (nothing to manage), but they still need to be fetched for reference/UUID-resolution purposes. The generated \`endpoints/ise.yaml\` is updated to reflect this override.

## Changes

- \`nac_collector/resources/endpoint_overrides/ise.yaml\` — added \`extra_endpoints\` section with \`profiler_profile\` entry; this is the source of truth and survives future runs of \`update_endpoints.py\`
- \`nac_collector/resources/endpoints/ise.yaml\` — regenerated to include the \`profiler_profile\` entry (output of the override)

## Test plan

Ran the collector against a live ISE node (ISE 3.3.0 Patch 7). Before the fix, \`profiler_profile\` was absent from the output JSON. After:

```
INFO     Processing endpoint: profiler_profile
INFO     GET /ers/config/profilerprofile?size=100 succeeded with status code 200
```

Output ZIP confirmed 893 profiler profile entries collected, each containing \`id\` and \`name\` fields.

All 268 unit tests passed:
```
========================= 268 passed, 3 warnings in 0.95s =========================
```

Pre-commit (ruff-check, ruff-format, mypy, bandit) — all passed.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Identified correct fix location (endpoint_overrides vs endpoints), applied fix, ran tests and live node verification
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae